### PR TITLE
Make --force-build actually force build

### DIFF
--- a/src/pier/cli/critique.py
+++ b/src/pier/cli/critique.py
@@ -164,11 +164,15 @@ def run_command(
         bool | None,
         Option(
             "--force-build/--no-force-build",
-            help=f"Whether to force rebuild the environment (default: {
-                '--force-build'
-                if EnvironmentConfig.model_fields['force_build'].default
-                else '--no-force-build'
-            })",
+            help=(
+                "Whether to force rebuild the environment; local Docker builds "
+                "use --no-cache when enabled (default: %s)"
+                % (
+                    "--force-build"
+                    if EnvironmentConfig.model_fields["force_build"].default
+                    else "--no-force-build"
+                )
+            ),
             rich_help_panel="Environment",
             show_default=False,
         ),

--- a/src/pier/cli/jobs.py
+++ b/src/pier/cli/jobs.py
@@ -379,11 +379,15 @@ def start(
         bool | None,
         Option(
             "--force-build/--no-force-build",
-            help=f"Whether to force rebuild the environment (default: {
-                '--force-build'
-                if EnvironmentConfig.model_fields['force_build'].default
-                else '--no-force-build'
-            })",
+            help=(
+                "Whether to force rebuild the environment; local Docker builds "
+                "use --no-cache when enabled (default: %s)"
+                % (
+                    "--force-build"
+                    if EnvironmentConfig.model_fields["force_build"].default
+                    else "--no-force-build"
+                )
+            ),
             rich_help_panel="Environment",
             show_default=False,
         ),

--- a/src/pier/environments/agent_setup.py
+++ b/src/pier/environments/agent_setup.py
@@ -61,6 +61,16 @@ def write_agent_dockerfile(
         source = source_environment_dir / "Dockerfile"
         dockerfile = [source.read_text()]
 
+    fingerprint = install.fingerprint()
+    dockerfile.extend(
+        [
+            f"ARG PIER_AGENT_INSTALL_FINGERPRINT={fingerprint}",
+            docker_run_command(
+                'printf "Pier agent install fingerprint: %s\\n" '
+                '"$PIER_AGENT_INSTALL_FINGERPRINT"'
+            ),
+        ]
+    )
     dockerfile.extend(dockerfile_install_commands(install, user=user))
     dockerfile.append("")
     dockerfile_path.write_text("\n".join(dockerfile))

--- a/src/pier/environments/docker/docker.py
+++ b/src/pier/environments/docker/docker.py
@@ -462,6 +462,13 @@ class DockerEnvironment(BaseEnvironment):
                 "not found. Please ensure at least one of these files exist."
             )
 
+    @staticmethod
+    def _build_command(*, force_build: bool) -> list[str]:
+        command = ["build"]
+        if force_build:
+            command.append("--no-cache")
+        return command
+
     async def _run_docker_compose_command(
         self, command: list[str], check: bool = True, timeout_sec: int | None = None
     ) -> ExecResult:
@@ -627,7 +634,9 @@ class DockerEnvironment(BaseEnvironment):
                 self.environment_name, asyncio.Lock()
             )
             async with lock:
-                await self._run_docker_compose_command(["build"])
+                await self._run_docker_compose_command(
+                    self._build_command(force_build=force_build)
+                )
 
         # Validate image OS after build/pull but before container start.
         image_to_check = (

--- a/src/pier/models/trial/config.py
+++ b/src/pier/models/trial/config.py
@@ -75,7 +75,13 @@ class AgentConfig(BaseModel):
 class EnvironmentConfig(BaseModel):
     type: EnvironmentType | None = None
     import_path: str | None = None
-    force_build: bool = False
+    force_build: bool = Field(
+        default=False,
+        description=(
+            "Whether to force rebuild the environment. For local Docker builds, "
+            "this also disables Docker layer cache."
+        ),
+    )
     delete: bool = True
     cpu_enforcement_policy: ResourceMode = ResourceMode.AUTO
     memory_enforcement_policy: ResourceMode = ResourceMode.AUTO

--- a/src/pier/models/trial/config.py
+++ b/src/pier/models/trial/config.py
@@ -75,13 +75,7 @@ class AgentConfig(BaseModel):
 class EnvironmentConfig(BaseModel):
     type: EnvironmentType | None = None
     import_path: str | None = None
-    force_build: bool = Field(
-        default=False,
-        description=(
-            "Whether to force rebuild the environment. For local Docker builds, "
-            "this also disables Docker layer cache."
-        ),
-    )
+    force_build: bool = False
     delete: bool = True
     cpu_enforcement_policy: ResourceMode = ResourceMode.AUTO
     memory_enforcement_policy: ResourceMode = ResourceMode.AUTO


### PR DESCRIPTION
When you update build steps for some environment or harness (e.g., `mini-swe-agent.py`), `--force-build` will not actually force the next run to ignore the cache and rebuild the image. This change fixes that by fingerprinting agent installs when the image is built.