### PR TITLE
Cache-aware pricing: fail loud on missing cache-read rate + JSON pricing overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,15 @@ For Gemini 3 via mini-swe-agent/LiteLLM, omitting `reasoning_effort` uses the Ge
 
 ### Cost computation & pricing overrides
 
-When an adapter computes `cost_usd` from token counts, it resolves per-token
-rates through `pier.utils.pricing`: a user-supplied overrides file first, then
-LiteLLM's `model_cost` table. Cache **reads** are billed at the model's
-discounted `cache_read_input_token_cost`, and the uncached remainder at the full
-input rate.
+When an adapter computes `cost_usd` from token counts (codex, gemini-cli,
+cursor-cli, and mini-swe-agent), it resolves per-token rates through
+`pier.utils.pricing`, in order: a user-supplied **overrides file**, then
+LiteLLM's `model_cost` table, then a small **built-in supplementary table** for
+models LiteLLM doesn't yet ship (e.g. `deepseek-v4-pro`). Cache **reads** are
+billed at the model's discounted `cache_read_input_token_cost`, and the uncached
+remainder at the full input rate. (For mini-swe-agent this cache-aware figure
+replaces the reported cost only when the model can be priced completely;
+otherwise the reported cost is kept.)
 
 If a model has no known cache-read rate but the run *used* cached tokens, cost is
 left **unpriced** (`cost_usd = null`) with an error log, rather than silently

--- a/README.md
+++ b/README.md
@@ -129,3 +129,33 @@ For Gemini 3 via mini-swe-agent/LiteLLM, omitting `reasoning_effort` uses the Ge
   kwargs:
     set_cache_control: default_end
 ```
+
+### Cost computation & pricing overrides
+
+When an adapter computes `cost_usd` from token counts, it resolves per-token
+rates through `pier.utils.pricing`: a user-supplied overrides file first, then
+LiteLLM's `model_cost` table. Cache **reads** are billed at the model's
+discounted `cache_read_input_token_cost`, and the uncached remainder at the full
+input rate.
+
+If a model has no known cache-read rate but the run *used* cached tokens, cost is
+left **unpriced** (`cost_usd = null`) with an error log, rather than silently
+billing those tokens at the full input rate — because cache reads dominate agent
+trajectories, that fallback can overstate cost severalfold.
+
+To price a model LiteLLM doesn't know (or to supply a missing cache-read rate),
+point `PIER_PRICING_FILE` at a JSON file mapping model name to rate fields (USD
+per token, same schema as `litellm.model_cost`):
+
+```json
+{
+  "deepseek-v4-pro": {
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+    "cache_read_input_token_cost": 3.625e-9
+  }
+}
+```
+
+Set `PIER_PRICING_FALLBACK=input` to restore the legacy behavior of billing
+cache reads at the input rate when no cache-read price is available.

--- a/src/pier/agents/installed/codex.py
+++ b/src/pier/agents/installed/codex.py
@@ -28,6 +28,7 @@ from pier.models.trajectories import (
 )
 from pier.models.trial.paths import EnvironmentPaths
 from pier.utils.env import parse_bool_env_value
+from pier.utils.pricing import compute_cost
 from pier.utils.trajectory_metrics import (
     extra_with_context_metrics,
     populate_context_from_final_metrics,
@@ -560,45 +561,18 @@ class Codex(BaseInstalledAgent):
         completion_tokens: int | None,
         cached_tokens: int | None,
     ) -> float | None:
-        """Compute total cost in USD from token counts via LiteLLM pricing."""
-        if not self.model_name:
-            return None
+        """Compute total cost in USD from token counts via resolved pricing.
 
-        try:
-            import litellm
-        except ImportError:
-            self.logger.warning("litellm not available; leaving codex cost_usd as None")
-            return None
-
-        pricing: dict[str, Any] | None = None
-        for key in (self.model_name, self.model_name.split("/", 1)[-1]):
-            entry = litellm.model_cost.get(key)
-            if entry:
-                pricing = entry
-                break
-
-        if pricing is None:
-            self.logger.warning(
-                "No LiteLLM pricing entry for model '%s'; leaving codex "
-                "cost_usd as None",
-                self.model_name,
-            )
-            return None
-
-        input_rate = pricing.get("input_cost_per_token") or 0.0
-        output_rate = pricing.get("output_cost_per_token") or 0.0
-        cache_read_rate = pricing.get("cache_read_input_token_cost", input_rate)
-        if cache_read_rate is None:
-            cache_read_rate = input_rate
-
-        uncached_input = max(0, (prompt_tokens or 0) - (cached_tokens or 0))
-        cached = cached_tokens or 0
-        output = completion_tokens or 0
-
-        return (
-            uncached_input * input_rate
-            + cached * cache_read_rate
-            + output * output_rate
+        Delegates to :func:`pier.utils.pricing.compute_cost`, which prices cache
+        reads at their discounted rate and refuses to silently bill them at the
+        full input rate when that rate is unknown (see the module docstring).
+        """
+        return compute_cost(
+            self.model_name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            logger=self.logger,
         )
 
     def _convert_events_to_trajectory(self, session_dir: Path) -> Trajectory | None:

--- a/src/pier/agents/installed/cursor_cli.py
+++ b/src/pier/agents/installed/cursor_cli.py
@@ -25,6 +25,7 @@ from pier.models.trajectories import (
     ToolCall,
     Trajectory,
 )
+from pier.utils.pricing import resolve_cache_read_rate, resolve_model_pricing
 from pier.utils.trajectory_metrics import (
     extra_with_context_metrics,
     peak_context_tokens_from_steps,
@@ -304,22 +305,7 @@ class CursorCli(BaseInstalledAgent):
         if builtin is not None:
             return builtin, "cursor_pricing"
 
-        try:
-            import litellm
-        except ImportError:
-            self.logger.warning(
-                "litellm not available and no built-in pricing for model '%s'; "
-                "leaving cursor-cli cost_usd as None",
-                self.model_name,
-            )
-            return None
-
-        pricing: dict[str, Any] | None = None
-        for key in (self.model_name, self.model_name.split("/", 1)[-1]):
-            entry = litellm.model_cost.get(key)
-            if entry:
-                pricing = entry
-                break
+        pricing = resolve_model_pricing(self.model_name, logger=self.logger)
         if pricing is None:
             self.logger.warning(
                 "No pricing entry for model '%s'; leaving cursor-cli cost_usd as None",
@@ -327,23 +313,27 @@ class CursorCli(BaseInstalledAgent):
             )
             return None
 
-        input_rate = pricing.get("input_cost_per_token") or 0.0
-        output_rate = pricing.get("output_cost_per_token") or 0.0
-        cache_read_rate = pricing.get("cache_read_input_token_cost", input_rate)
+        # Cursor trajectories use prompt caching; refuse to silently bill cache
+        # reads at the full input rate when the discounted rate is unknown.
+        cache_read_rate = resolve_cache_read_rate(
+            pricing, used_cached_tokens=True, logger=self.logger
+        )
         if cache_read_rate is None:
-            cache_read_rate = input_rate
-        cache_write_rate = pricing.get("cache_creation_input_token_cost", input_rate)
-        if cache_write_rate is None:
-            cache_write_rate = input_rate
+            return None  # left unpriced; resolve_cache_read_rate logged why
+        cache_write_rate = (
+            pricing.cache_creation_input_token_cost
+            if pricing.cache_creation_input_token_cost is not None
+            else pricing.input_cost_per_token
+        )
 
         return (
             {
-                "input": input_rate,
-                "output": output_rate,
+                "input": pricing.input_cost_per_token,
+                "output": pricing.output_cost_per_token,
                 "cache_read": cache_read_rate,
                 "cache_write": cache_write_rate,
             },
-            "litellm",
+            pricing.source,
         )
 
     def _compute_cost_from_usage_totals(

--- a/src/pier/agents/installed/gemini_cli.py
+++ b/src/pier/agents/installed/gemini_cli.py
@@ -27,6 +27,7 @@ from pier.models.trajectories import (
     ToolCall,
     Trajectory,
 )
+from pier.utils.pricing import compute_cost
 from pier.utils.trajectory_metrics import (
     extra_with_context_metrics,
     peak_context_tokens_from_steps,
@@ -544,38 +545,19 @@ class GeminiCli(BaseInstalledAgent):
         completion_tokens: int | None,
         cached_tokens: int | None,
     ) -> float | None:
-        if not self.model_name:
-            return None
+        """Compute total cost in USD from token counts via resolved pricing.
 
-        try:
-            import litellm
-        except ImportError:
-            self.logger.warning("litellm not available; cost_usd left as None")
-            return None
-
-        pricing: dict[str, Any] | None = None
-        for key in (self.model_name, self.model_name.split("/", 1)[-1]):
-            entry = litellm.model_cost.get(key)
-            if entry:
-                pricing = entry
-                break
-
-        if pricing is None:
-            self.logger.warning(
-                "No LiteLLM pricing for '%s'; cost_usd left as None",
-                self.model_name,
-            )
-            return None
-
-        input_rate = pricing.get("input_cost_per_token") or 0.0
-        output_rate = pricing.get("output_cost_per_token") or 0.0
-        cache_read_rate = pricing.get("cache_read_input_token_cost") or input_rate
-
-        uncached = max(0, (prompt_tokens or 0) - (cached_tokens or 0))
-        cached = cached_tokens or 0
-        output = completion_tokens or 0
-
-        return uncached * input_rate + cached * cache_read_rate + output * output_rate
+        Delegates to :func:`pier.utils.pricing.compute_cost`, which prices cache
+        reads at their discounted rate and refuses to silently bill them at the
+        full input rate when that rate is unknown (see the module docstring).
+        """
+        return compute_cost(
+            self.model_name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            logger=self.logger,
+        )
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         gemini_path: Path | None = None

--- a/src/pier/agents/installed/mini_swe_agent.py
+++ b/src/pier/agents/installed/mini_swe_agent.py
@@ -30,6 +30,7 @@ from pier.models.trajectories import (
     Trajectory,
 )
 from pier.models.trial.paths import EnvironmentPaths
+from pier.utils.pricing import compute_cost
 from pier.utils.trajectory_metrics import (
     extra_with_context_metrics,
     peak_context_tokens_from_steps,
@@ -158,9 +159,7 @@ def _build_step_metrics(
     )
 
 
-def _parse_tool_calls(
-    message: dict[str, Any], step_id: int
-) -> list[ToolCall] | None:
+def _parse_tool_calls(message: dict[str, Any], step_id: int) -> list[ToolCall] | None:
     """Parse tool calls from an assistant message into ATIF ToolCall objects."""
     message_tool_calls = message.get("tool_calls")
     if not message_tool_calls:
@@ -340,7 +339,9 @@ def convert_mini_swe_agent_to_atif(
             usage.get("completion_tokens") or usage.get("output_tokens") or 0
         )
         prompt_tokens_details = (
-            usage.get("prompt_tokens_details") or usage.get("input_tokens_details") or {}
+            usage.get("prompt_tokens_details")
+            or usage.get("input_tokens_details")
+            or {}
         )
         if not isinstance(prompt_tokens_details, dict):
             prompt_tokens_details = {}
@@ -623,7 +624,9 @@ class MiniSweAgent(BaseInstalledAgent):
         version_spec = f"=={self._version}" if self._version else ""
         install_extra_packages = ""
         if self._install_python_packages:
-            packages = " ".join(shlex.quote(pkg) for pkg in self._install_python_packages)
+            packages = " ".join(
+                shlex.quote(pkg) for pkg in self._install_python_packages
+            )
             install_extra_packages = (
                 f'uv pip install --python "$python_bin" {packages}\n'
             )
@@ -781,13 +784,32 @@ mini-swe-agent --help
 
         if self._set_cache_control:
             config_flags += (
-                f"-c model.set_cache_control="
-                f"{shlex.quote(self._set_cache_control)} "
+                f"-c model.set_cache_control={shlex.quote(self._set_cache_control)} "
             )
 
         config_flags += self._model_kwargs_config_flags()
 
         return config_flags
+
+    def _compute_cost_from_pricing(
+        self,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+        cached_tokens: int | None,
+    ) -> float | None:
+        """Cache-aware cost from token counts via the shared pricing helper.
+
+        Returns ``None`` when the model can't be priced safely (e.g. cached
+        tokens were used but no cache-read rate is known); callers keep the
+        reported cost in that case.
+        """
+        return compute_cost(
+            self.model_name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            logger=self.logger,
+        )
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         # Read the mini-swe-agent trajectory
@@ -812,6 +834,20 @@ mini-swe-agent --help
                 populate_context_from_final_metrics(
                     context, atif_trajectory.final_metrics
                 )
+                # Recompute with cache-aware pricing. mini-swe-agent's reported
+                # cost bills every prompt token at the input rate when a model
+                # lacks a cache-read price, overstating cache-heavy runs (see
+                # datacurve-ai/deep-swe#21). When we can price the model
+                # completely, that cache-aware figure is authoritative; when we
+                # can't (compute_cost returns None / fail-loud), the reported
+                # cost is left untouched.
+                cache_aware_cost = self._compute_cost_from_pricing(
+                    prompt_tokens=context.n_input_tokens,
+                    completion_tokens=context.n_output_tokens,
+                    cached_tokens=context.n_cache_tokens,
+                )
+                if cache_aware_cost is not None:
+                    context.cost_usd = cache_aware_cost
         except Exception as e:
             self.logger.debug(f"Failed to convert trajectory to ATIF format: {e}")
 

--- a/src/pier/utils/pricing.py
+++ b/src/pier/utils/pricing.py
@@ -67,7 +67,27 @@ class ModelPricing:
     output_cost_per_token: float
     cache_read_input_token_cost: float | None
     cache_creation_input_token_cost: float | None
-    source: str  # "override" or "litellm"
+    source: str  # "override", "litellm", or "supplementary"
+
+
+# Curated rates for models LiteLLM's registry is missing or lags on. This is a
+# stopgap so cost is correct out of the box for known gaps -- the long-term fix
+# is upstreaming these to litellm (model_prices_and_context_window.json). It is
+# consulted only after the user overrides file and litellm, and anything here can
+# be overridden or extended via PIER_PRICING_FILE. Rates are USD per token.
+# deepseek-v4-* rates from datacurve-ai/deep-swe#21 and PR #4 (thanks @dephnor).
+SUPPLEMENTARY_PRICING: dict[str, dict[str, float]] = {
+    "deepseek-v4-pro": {
+        "input_cost_per_token": 0.435 / 1_000_000,
+        "output_cost_per_token": 0.87 / 1_000_000,
+        "cache_read_input_token_cost": 0.003625 / 1_000_000,
+    },
+    "deepseek-v4-flash": {
+        "input_cost_per_token": 0.14 / 1_000_000,
+        "output_cost_per_token": 0.28 / 1_000_000,
+        "cache_read_input_token_cost": 0.0028 / 1_000_000,
+    },
+}
 
 
 # Simple mtime-keyed cache so an edited overrides file is picked up without a
@@ -134,21 +154,25 @@ def resolve_model_pricing(
     if not model_name:
         return None
 
+    # Resolution order: user overrides -> litellm -> shipped supplementary gaps.
     entry = _lookup(load_pricing_overrides(), model_name)
     source = "override"
     if entry is None:
         try:
             import litellm
+
+            entry = _lookup(litellm.model_cost, model_name)
+            source = "litellm"
         except ImportError:
-            logger.error(
-                "litellm is not installed and no %s entry exists for %r; "
-                "cannot compute cost",
+            logger.warning(
+                "litellm is not installed; relying on %s and built-in "
+                "supplementary pricing for %r",
                 PRICING_FILE_ENV,
                 model_name,
             )
-            return None
-        entry = _lookup(litellm.model_cost, model_name)
-        source = "litellm"
+    if entry is None:
+        entry = _lookup(SUPPLEMENTARY_PRICING, model_name)
+        source = "supplementary"
 
     if entry is None:
         return None

--- a/src/pier/utils/pricing.py
+++ b/src/pier/utils/pricing.py
@@ -1,0 +1,269 @@
+"""Cache-aware model pricing resolution for token-based cost computation.
+
+Rates are expressed in USD per token, matching the schema of
+``litellm.model_cost`` entries (``input_cost_per_token``,
+``output_cost_per_token``, ``cache_read_input_token_cost`` and
+``cache_creation_input_token_cost``).
+
+Two sources are consulted, in order:
+
+1. A user-supplied JSON overrides file pointed to by the ``PIER_PRICING_FILE``
+   environment variable. Use it to price models LiteLLM does not know about, or
+   to supply a cache-read rate LiteLLM is missing, without waiting on a LiteLLM
+   release.
+2. LiteLLM's built-in ``model_cost`` table.
+
+Fail-loud policy
+----------------
+Agent trajectories are dominated by cache *reads*. Historically each adapter
+silently fell back to the full (cache-miss) input rate whenever a model lacked a
+``cache_read_input_token_cost`` entry. Because cache reads are typically priced
+at a steep discount (often 80-99% off the input rate) and make up the large
+majority of prompt tokens, that silent fallback can overstate cost severalfold.
+
+This module refuses to do that silently. When a run used cached tokens but no
+cache-read price is known, :func:`compute_cost` logs an error and returns
+``None`` (cost unavailable) rather than emitting a confidently-wrong number.
+Supply the rate via ``PIER_PRICING_FILE``, or set ``PIER_PRICING_FALLBACK=input``
+to explicitly opt back into the approximate (inflated) input-rate fallback.
+
+Overrides file format
+---------------------
+A JSON object mapping model name to a subset of the LiteLLM rate fields::
+
+    {
+      "deepseek-v4-pro": {
+        "input_cost_per_token": 4.35e-7,
+        "output_cost_per_token": 8.7e-7,
+        "cache_read_input_token_cost": 3.625e-9
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+PRICING_FILE_ENV = "PIER_PRICING_FILE"
+PRICING_FALLBACK_ENV = "PIER_PRICING_FALLBACK"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PricingConfigError(RuntimeError):
+    """Raised when ``PIER_PRICING_FILE`` is set but cannot be read or parsed."""
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Resolved per-token rates for a model (USD per token)."""
+
+    model_name: str
+    input_cost_per_token: float
+    output_cost_per_token: float
+    cache_read_input_token_cost: float | None
+    cache_creation_input_token_cost: float | None
+    source: str  # "override" or "litellm"
+
+
+# Simple mtime-keyed cache so an edited overrides file is picked up without a
+# restart, while avoiding a re-read on every cost computation.
+_OVERRIDES_CACHE: dict[str, Any] = {}
+
+
+def load_pricing_overrides() -> dict[str, dict[str, Any]]:
+    """Load and cache the ``PIER_PRICING_FILE`` overrides (``{}`` if unset).
+
+    Raises :class:`PricingConfigError` if the variable is set but the file is
+    missing or not a JSON object -- a misconfiguration the caller asked for and
+    should hear about loudly.
+    """
+    path = os.environ.get(PRICING_FILE_ENV)
+    if not path:
+        return {}
+
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError as exc:
+        raise PricingConfigError(
+            f"{PRICING_FILE_ENV}={path!r} could not be read: {exc}"
+        ) from exc
+
+    if _OVERRIDES_CACHE.get("path") != path or _OVERRIDES_CACHE.get("mtime") != mtime:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PricingConfigError(
+                f"{PRICING_FILE_ENV}={path!r} is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise PricingConfigError(
+                f"{PRICING_FILE_ENV}={path!r} must be a JSON object mapping "
+                f"model name -> rate fields"
+            )
+        _OVERRIDES_CACHE.update(path=path, mtime=mtime, data=data)
+
+    return _OVERRIDES_CACHE["data"]
+
+
+def _lookup(table: dict[str, Any], model_name: str) -> dict[str, Any] | None:
+    """Look up a model by full name then by the part after the first ``/``."""
+    for key in (model_name, model_name.split("/", 1)[-1]):
+        entry = table.get(key)
+        if entry:
+            return entry
+    return None
+
+
+def resolve_model_pricing(
+    model_name: str | None,
+    *,
+    logger: logging.Logger | None = None,
+) -> ModelPricing | None:
+    """Resolve pricing for ``model_name`` from overrides then LiteLLM.
+
+    Returns ``None`` when no source knows the model, or when an entry lacks the
+    mandatory input/output rates.
+    """
+    logger = logger or _LOGGER
+    if not model_name:
+        return None
+
+    entry = _lookup(load_pricing_overrides(), model_name)
+    source = "override"
+    if entry is None:
+        try:
+            import litellm
+        except ImportError:
+            logger.error(
+                "litellm is not installed and no %s entry exists for %r; "
+                "cannot compute cost",
+                PRICING_FILE_ENV,
+                model_name,
+            )
+            return None
+        entry = _lookup(litellm.model_cost, model_name)
+        source = "litellm"
+
+    if entry is None:
+        return None
+
+    input_rate = entry.get("input_cost_per_token")
+    output_rate = entry.get("output_cost_per_token")
+    if input_rate is None or output_rate is None:
+        return None
+
+    def _opt(field: str) -> float | None:
+        value = entry.get(field)
+        return None if value is None else float(value)
+
+    return ModelPricing(
+        model_name=model_name,
+        input_cost_per_token=float(input_rate),
+        output_cost_per_token=float(output_rate),
+        cache_read_input_token_cost=_opt("cache_read_input_token_cost"),
+        cache_creation_input_token_cost=_opt("cache_creation_input_token_cost"),
+        source=source,
+    )
+
+
+def _fallback_to_input_rate() -> bool:
+    return os.environ.get(PRICING_FALLBACK_ENV, "").strip().lower() == "input"
+
+
+def resolve_cache_read_rate(
+    pricing: ModelPricing,
+    *,
+    used_cached_tokens: bool,
+    logger: logging.Logger | None = None,
+) -> float | None:
+    """Return the cache-read rate, applying the fail-loud policy.
+
+    ``None`` means "do not price this": the run used cached tokens, no cache-read
+    rate is known, and ``PIER_PRICING_FALLBACK=input`` was not set. When no
+    cached tokens were used the rate is irrelevant and the input rate is returned.
+    """
+    logger = logger or _LOGGER
+    if pricing.cache_read_input_token_cost is not None:
+        return pricing.cache_read_input_token_cost
+    if not used_cached_tokens:
+        return pricing.input_cost_per_token
+    if _fallback_to_input_rate():
+        logger.warning(
+            "No cache-read price for %r (source=%s); %s=input set, billing cached "
+            "tokens at the full input rate -- this overstates cost.",
+            pricing.model_name,
+            pricing.source,
+            PRICING_FALLBACK_ENV,
+        )
+        return pricing.input_cost_per_token
+    logger.error(
+        "No cache-read price for model %r (source=%s) but the run used cached "
+        "input tokens. Billing them at the full input rate would overstate cost "
+        "severalfold, so cost is left unpriced. Add "
+        "'cache_read_input_token_cost' for this model via %s, or set %s=input to "
+        "accept the approximate fallback.",
+        pricing.model_name,
+        pricing.source,
+        PRICING_FILE_ENV,
+        PRICING_FALLBACK_ENV,
+    )
+    return None
+
+
+def compute_cost(
+    model_name: str | None,
+    *,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+    cached_tokens: int | None = 0,
+    cache_creation_tokens: int | None = 0,
+    logger: logging.Logger | None = None,
+) -> float | None:
+    """Total USD cost from token counts, or ``None`` if it cannot be priced safely.
+
+    ``prompt_tokens`` is the full prompt size *including* cache reads and writes
+    (the OpenAI / LiteLLM convention); ``cached_tokens`` is the cache-read subset
+    and ``cache_creation_tokens`` the cache-write subset. Returns ``None`` -- with
+    an error log -- when pricing is unavailable, including the case where cached
+    tokens were used but no cache-read rate is known (see module docstring).
+    """
+    logger = logger or _LOGGER
+    pricing = resolve_model_pricing(model_name, logger=logger)
+    if pricing is None:
+        logger.error(
+            "No pricing for model %r; leaving cost unpriced. Set %s to a JSON file "
+            "mapping the model to its per-token rates.",
+            model_name,
+            PRICING_FILE_ENV,
+        )
+        return None
+
+    cached = cached_tokens or 0
+    created = cache_creation_tokens or 0
+    completion = completion_tokens or 0
+    uncached = max(0, (prompt_tokens or 0) - cached - created)
+
+    cache_read_rate = resolve_cache_read_rate(
+        pricing, used_cached_tokens=cached > 0, logger=logger
+    )
+    if cache_read_rate is None:
+        return None
+
+    cache_write_rate = (
+        pricing.cache_creation_input_token_cost
+        if pricing.cache_creation_input_token_cost is not None
+        else pricing.input_cost_per_token
+    )
+
+    return (
+        uncached * pricing.input_cost_per_token
+        + cached * cache_read_rate
+        + created * cache_write_rate
+        + completion * pricing.output_cost_per_token
+    )

--- a/src/pier/viewer/server.py
+++ b/src/pier/viewer/server.py
@@ -23,6 +23,7 @@ from pier.models.job.config import (
 )
 from pier.models.job.result import JobStats
 from pier.models.trial.result import TrialResult
+from pier.utils.pricing import resolve_model_pricing
 from pier.viewer.models import (
     CritiqueHeatmapCell,
     CritiqueHeatmapColumn,
@@ -209,40 +210,25 @@ def create_app(
             ..., description="Model name, e.g. 'gpt-4' or 'openai/gpt-4'"
         ),
     ) -> ModelPricing:
-        """Look up per-token pricing for a model from LiteLLM's pricing table.
+        """Look up per-token pricing for a model.
 
-        Falls back to the bare model name when the provider-prefixed form is
-        not in the table (e.g. ``openai/gpt-4`` -> ``gpt-4``). Cache read
-        rate falls back to the input rate when not separately listed.
+        Resolved from the ``PIER_PRICING_FILE`` overrides then LiteLLM, falling
+        back to the bare model name when the provider-prefixed form is not in the
+        table (e.g. ``openai/gpt-4`` -> ``gpt-4``). The cache-read rate is
+        reported as ``null`` when not separately listed, rather than mirroring
+        the input rate (which would misrepresent the true cost of cache hits).
         """
-        try:
-            import litellm
-        except ImportError as e:
-            raise HTTPException(status_code=503, detail="LiteLLM not available") from e
-
-        pricing: dict[str, Any] | None = None
-        for key in (model, model.split("/", 1)[-1]):
-            entry = litellm.model_cost.get(key)
-            if entry:
-                pricing = entry
-                break
-
+        pricing = resolve_model_pricing(model)
         if pricing is None:
             raise HTTPException(
                 status_code=404, detail=f"No pricing entry for model '{model}'"
             )
 
-        input_rate = pricing.get("input_cost_per_token")
-        output_rate = pricing.get("output_cost_per_token")
-        cache_read_rate = pricing.get("cache_read_input_token_cost")
-        if cache_read_rate is None:
-            cache_read_rate = input_rate
-
         return ModelPricing(
             model_name=model,
-            input_cost_per_token=input_rate,
-            cache_read_input_token_cost=cache_read_rate,
-            output_cost_per_token=output_rate,
+            input_cost_per_token=pricing.input_cost_per_token,
+            cache_read_input_token_cost=pricing.cache_read_input_token_cost,
+            output_cost_per_token=pricing.output_cost_per_token,
         )
 
     if mode == "tasks":

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,160 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from pier.utils.pricing import (
+    PRICING_FALLBACK_ENV,
+    PRICING_FILE_ENV,
+    PricingConfigError,
+    _OVERRIDES_CACHE,
+    compute_cost,
+    load_pricing_overrides,
+    resolve_model_pricing,
+)
+
+# A model with a steep cache discount (DeepSeek-style: cache reads ~0.8% of input).
+DEEPSEEK_RATES = {
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+    "cache_read_input_token_cost": 3.625e-9,
+}
+# Same model but *missing* the cache-read rate -- the trap this module guards.
+DEEPSEEK_NO_CACHE = {
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides_cache(monkeypatch):
+    """Each test starts with a clean overrides cache and no pricing env vars."""
+    _OVERRIDES_CACHE.clear()
+    monkeypatch.delenv(PRICING_FILE_ENV, raising=False)
+    monkeypatch.delenv(PRICING_FALLBACK_ENV, raising=False)
+    yield
+    _OVERRIDES_CACHE.clear()
+
+
+def _write_overrides(tmp_path: Path, mapping: dict) -> Path:
+    path = tmp_path / "pricing.json"
+    path.write_text(json.dumps(mapping), encoding="utf-8")
+    return path
+
+
+def test_load_overrides_empty_when_unset():
+    assert load_pricing_overrides() == {}
+
+
+def test_resolve_prefers_override_file(tmp_path, monkeypatch):
+    path = _write_overrides(tmp_path, {"deepseek-v4-pro": DEEPSEEK_RATES})
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+    pricing = resolve_model_pricing("deepseek-v4-pro")
+
+    assert pricing is not None
+    assert pricing.source == "override"
+    assert pricing.cache_read_input_token_cost == pytest.approx(3.625e-9)
+
+
+def test_resolve_strips_provider_prefix(tmp_path, monkeypatch):
+    path = _write_overrides(tmp_path, {"deepseek-v4-pro": DEEPSEEK_RATES})
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+    pricing = resolve_model_pricing("deepseek/deepseek-v4-pro")
+
+    assert pricing is not None
+    assert pricing.input_cost_per_token == pytest.approx(4.35e-7)
+
+
+def test_compute_cost_discounts_cache_reads(tmp_path, monkeypatch):
+    path = _write_overrides(tmp_path, {"deepseek-v4-pro": DEEPSEEK_RATES})
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+    # 8.99M prompt tokens of which 7.08M are cache hits (the issue's trial).
+    cost = compute_cost(
+        "deepseek-v4-pro",
+        prompt_tokens=8_986_237,
+        completion_tokens=43_110,
+        cached_tokens=7_078_144,
+    )
+
+    # Hand-computed: uncached 1.908M @ 4.35e-7 + cache 7.078M @ 3.625e-9
+    # + output 43.11k @ 8.7e-7  ~= $0.89 -- not the ~$4.36 a miss-rate bill gives.
+    assert cost == pytest.approx(0.8939, abs=1e-3)
+
+
+def test_missing_cache_rate_with_cached_tokens_returns_none(
+    tmp_path, monkeypatch, caplog
+):
+    """The core fix: do not silently bill cache reads at the input rate."""
+    path = _write_overrides(tmp_path, {"deepseek-v4-pro": DEEPSEEK_NO_CACHE})
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+    with caplog.at_level("ERROR"):
+        cost = compute_cost(
+            "deepseek-v4-pro",
+            prompt_tokens=8_986_237,
+            completion_tokens=43_110,
+            cached_tokens=7_078_144,
+        )
+
+    assert cost is None
+    assert any("cache-read price" in r.message for r in caplog.records)
+
+
+def test_missing_cache_rate_without_cached_tokens_is_fine(tmp_path, monkeypatch):
+    """No cached tokens -> the absent cache rate is irrelevant; still prices."""
+    path = _write_overrides(tmp_path, {"deepseek-v4-pro": DEEPSEEK_NO_CACHE})
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+    cost = compute_cost(
+        "deepseek-v4-pro",
+        prompt_tokens=1_000_000,
+        completion_tokens=10_000,
+        cached_tokens=0,
+    )
+
+    assert cost == pytest.approx(1_000_000 * 4.35e-7 + 10_000 * 8.7e-7)
+
+
+def test_fallback_env_restores_legacy_input_rate(tmp_path, monkeypatch):
+    path = _write_overrides(tmp_path, {"deepseek-v4-pro": DEEPSEEK_NO_CACHE})
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+    monkeypatch.setenv(PRICING_FALLBACK_ENV, "input")
+
+    cost = compute_cost(
+        "deepseek-v4-pro",
+        prompt_tokens=1_000_000,
+        completion_tokens=0,
+        cached_tokens=400_000,
+    )
+
+    # Legacy behaviour: cache reads billed at the full input rate.
+    assert cost == pytest.approx(1_000_000 * 4.35e-7)
+
+
+def test_unknown_model_returns_none(caplog):
+    with caplog.at_level("ERROR"):
+        cost = compute_cost(
+            "totally-unknown-model-xyz",
+            prompt_tokens=1000,
+            completion_tokens=10,
+            cached_tokens=500,
+        )
+    assert cost is None
+
+
+def test_bad_overrides_file_raises(tmp_path, monkeypatch):
+    path = tmp_path / "pricing.json"
+    path.write_text("not json", encoding="utf-8")
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+    with pytest.raises(PricingConfigError):
+        load_pricing_overrides()
+
+
+def test_missing_overrides_file_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv(PRICING_FILE_ENV, str(tmp_path / "does-not-exist.json"))
+    with pytest.raises(PricingConfigError):
+        load_pricing_overrides()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -145,6 +145,30 @@ def test_unknown_model_returns_none(caplog):
     assert cost is None
 
 
+def test_supplementary_prices_model_absent_from_litellm():
+    """deepseek-v4-pro isn't in litellm; the shipped supplementary table covers it."""
+    pricing = resolve_model_pricing("deepseek-v4-pro")
+    assert pricing is not None
+    assert pricing.source == "supplementary"
+    assert pricing.cache_read_input_token_cost == pytest.approx(0.003625 / 1_000_000)
+
+
+def test_supplementary_strips_provider_prefix():
+    pricing = resolve_model_pricing("openrouter/deepseek-v4-pro")
+    assert pricing is not None and pricing.source == "supplementary"
+
+
+def test_override_beats_supplementary(tmp_path, monkeypatch):
+    path = _write_overrides(
+        tmp_path,
+        {"deepseek-v4-pro": {**DEEPSEEK_RATES, "input_cost_per_token": 9.9e-7}},
+    )
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+    pricing = resolve_model_pricing("deepseek-v4-pro")
+    assert pricing.source == "override"
+    assert pricing.input_cost_per_token == pytest.approx(9.9e-7)
+
+
 def test_bad_overrides_file_raises(tmp_path, monkeypatch):
     path = tmp_path / "pricing.json"
     path.write_text("not json", encoding="utf-8")

--- a/tests/test_pricing_integration.py
+++ b/tests/test_pricing_integration.py
@@ -1,0 +1,156 @@
+"""Integration tests that exercise the real adapter cost methods end-to-end.
+
+These drive the actual ``_compute_cost_from_pricing`` / ``_resolve_pricing_rates``
+methods on constructed adapters (not ``pier.utils.pricing`` directly), so the
+adapter -> shared-helper wiring is executed, not just imported.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pier.agents.installed.codex import Codex
+from pier.agents.installed.cursor_cli import CursorCli
+from pier.agents.installed.gemini_cli import GeminiCli
+from pier.utils.pricing import (
+    PRICING_FALLBACK_ENV,
+    PRICING_FILE_ENV,
+    _OVERRIDES_CACHE,
+)
+
+# DeepSeek-style steep cache discount (cache reads ~0.8% of the input rate).
+RATES = {
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+    "cache_read_input_token_cost": 3.625e-9,
+}
+RATES_NO_CACHE = {
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+}
+
+# The issue's representative trial: 8.99M prompt tokens, 7.08M of them cache hits.
+PROMPT, CACHED, OUTPUT = 8_986_237, 7_078_144, 43_110
+# Correct cache-aware cost ~= $0.89; billing cache at the input rate gives ~$4.36.
+EXPECTED_DISCOUNTED = 0.8939
+
+
+@pytest.fixture(autouse=True)
+def _clean_pricing_env(monkeypatch):
+    _OVERRIDES_CACHE.clear()
+    monkeypatch.delenv(PRICING_FILE_ENV, raising=False)
+    monkeypatch.delenv(PRICING_FALLBACK_ENV, raising=False)
+    yield
+    _OVERRIDES_CACHE.clear()
+
+
+def _overrides(tmp_path: Path, mapping: dict, monkeypatch) -> None:
+    path = tmp_path / "pricing.json"
+    path.write_text(json.dumps(mapping), encoding="utf-8")
+    monkeypatch.setenv(PRICING_FILE_ENV, str(path))
+
+
+@pytest.mark.parametrize("cls", [Codex, GeminiCli])
+def test_adapter_cost_discounts_cache_reads(cls, tmp_path, monkeypatch):
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES}, monkeypatch)
+    agent = cls(logs_dir=tmp_path, model_name="deepseek-v4-pro")
+
+    cost = agent._compute_cost_from_pricing(PROMPT, OUTPUT, CACHED)
+
+    assert cost == pytest.approx(EXPECTED_DISCOUNTED, abs=1e-3)
+    # Sanity: the discounted figure is far below the miss-rate bill (~$4.36).
+    assert cost < 1.5
+
+
+@pytest.mark.parametrize("cls", [Codex, GeminiCli])
+def test_adapter_fails_loud_on_missing_cache_rate(cls, tmp_path, monkeypatch, caplog):
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES_NO_CACHE}, monkeypatch)
+    agent = cls(logs_dir=tmp_path, model_name="deepseek-v4-pro")
+
+    with caplog.at_level("ERROR"):
+        cost = agent._compute_cost_from_pricing(PROMPT, OUTPUT, CACHED)
+
+    assert cost is None  # left unpriced rather than silently inflated
+    assert any("cache-read price" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize("cls", [Codex, GeminiCli])
+def test_adapter_fallback_env_restores_input_rate(cls, tmp_path, monkeypatch):
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES_NO_CACHE}, monkeypatch)
+    monkeypatch.setenv(PRICING_FALLBACK_ENV, "input")
+    agent = cls(logs_dir=tmp_path, model_name="deepseek-v4-pro")
+
+    cost = agent._compute_cost_from_pricing(PROMPT, OUTPUT, CACHED)
+
+    # Legacy behaviour: every prompt token billed at the input rate.
+    uncached_at_input = (PROMPT - CACHED) * RATES_NO_CACHE["input_cost_per_token"]
+    cache_at_input = CACHED * RATES_NO_CACHE["input_cost_per_token"]
+    output_cost = OUTPUT * RATES_NO_CACHE["output_cost_per_token"]
+    assert cost == pytest.approx(uncached_at_input + cache_at_input + output_cost)
+
+
+def test_cursor_resolve_pricing_rates_uses_override(tmp_path, monkeypatch):
+    # Use a non-Cursor model so the built-in Cursor pricing table is bypassed
+    # and resolution falls through to the overrides file.
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES}, monkeypatch)
+    agent = CursorCli(logs_dir=tmp_path, model_name="deepseek-v4-pro")
+
+    result = agent._resolve_pricing_rates()
+
+    assert result is not None
+    rates, source = result
+    assert source == "override"
+    assert rates["cache_read"] == pytest.approx(3.625e-9)
+    assert rates["input"] == pytest.approx(4.35e-7)
+
+
+def test_cursor_resolve_pricing_rates_fails_loud(tmp_path, monkeypatch, caplog):
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES_NO_CACHE}, monkeypatch)
+    agent = CursorCli(logs_dir=tmp_path, model_name="deepseek-v4-pro")
+
+    with caplog.at_level("ERROR"):
+        result = agent._resolve_pricing_rates()
+
+    assert result is None  # unpriced rather than silently billing cache at input
+    assert any("cache-read price" in r.message for r in caplog.records)
+
+
+def _viewer_client(tmp_path: Path):
+    from fastapi.testclient import TestClient
+
+    from pier.viewer.server import create_app
+
+    return TestClient(create_app(tmp_path, mode="jobs"))
+
+
+def test_viewer_pricing_endpoint_uses_override(tmp_path, monkeypatch):
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES}, monkeypatch)
+
+    resp = _viewer_client(tmp_path).get(
+        "/api/pricing", params={"model": "deepseek-v4-pro"}
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cache_read_input_token_cost"] == pytest.approx(3.625e-9)
+    assert body["input_cost_per_token"] == pytest.approx(4.35e-7)
+
+
+def test_viewer_pricing_reports_null_cache_rate_when_unlisted(tmp_path, monkeypatch):
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES_NO_CACHE}, monkeypatch)
+
+    resp = _viewer_client(tmp_path).get(
+        "/api/pricing", params={"model": "deepseek-v4-pro"}
+    )
+
+    assert resp.status_code == 200
+    # The honest behaviour: null rather than mirroring the input rate.
+    assert resp.json()["cache_read_input_token_cost"] is None
+
+
+def test_viewer_pricing_unknown_model_returns_404(tmp_path):
+    resp = _viewer_client(tmp_path).get(
+        "/api/pricing", params={"model": "totally-unknown-model-xyz"}
+    )
+    assert resp.status_code == 404

--- a/tests/test_pricing_integration.py
+++ b/tests/test_pricing_integration.py
@@ -13,6 +13,7 @@ import pytest
 from pier.agents.installed.codex import Codex
 from pier.agents.installed.cursor_cli import CursorCli
 from pier.agents.installed.gemini_cli import GeminiCli
+from pier.agents.installed.mini_swe_agent import MiniSweAgent
 from pier.utils.pricing import (
     PRICING_FALLBACK_ENV,
     PRICING_FILE_ENV,
@@ -113,6 +114,29 @@ def test_cursor_resolve_pricing_rates_fails_loud(tmp_path, monkeypatch, caplog):
         result = agent._resolve_pricing_rates()
 
     assert result is None  # unpriced rather than silently billing cache at input
+    assert any("cache-read price" in r.message for r in caplog.records)
+
+
+def test_mini_swe_agent_prices_deepseek_via_supplementary(tmp_path):
+    """mini-swe path: deepseek-v4-pro (absent from litellm) priced cache-aware
+    out of the box via the shipped supplementary table -- no override needed."""
+    agent = MiniSweAgent(logs_dir=tmp_path, model_name="openrouter/deepseek-v4-pro")
+
+    cost = agent._compute_cost_from_pricing(PROMPT, OUTPUT, CACHED)
+
+    # uncached 1.908M @ 4.35e-7 + cache 7.078M @ 3.625e-9 + out 43.11k @ 8.7e-7
+    assert cost == pytest.approx(EXPECTED_DISCOUNTED, abs=1e-3)
+
+
+def test_mini_swe_agent_fails_loud_on_missing_cache_rate(tmp_path, monkeypatch, caplog):
+    # Override strips the cache rate -> mini-swe leaves cost unpriced (keeps reported).
+    _overrides(tmp_path, {"deepseek-v4-pro": RATES_NO_CACHE}, monkeypatch)
+    agent = MiniSweAgent(logs_dir=tmp_path, model_name="openrouter/deepseek-v4-pro")
+
+    with caplog.at_level("ERROR"):
+        cost = agent._compute_cost_from_pricing(PROMPT, OUTPUT, CACHED)
+
+    assert cost is None
     assert any("cache-read price" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
## Problem

When an adapter computes `cost_usd` from token counts, it resolved per-token
rates from `litellm.model_cost` and **silently fell back to the full input
(cache-miss) rate whenever a model lacked a `cache_read_input_token_cost`
entry**. Because cache reads dominate agent trajectories (often 50–85% of prompt
tokens) and are steeply discounted (10×–120× off the input rate), that fallback
can overstate cost severalfold for affected models.

This is the root cause behind #21 (deepseek-v4-pro cost reported ~5× too high)
and likely #19. Two ways it bites today:
- `deepseek-v4-pro` is **absent from litellm entirely**.
- Even models litellm *does* know can omit the field — e.g.
  `azure_ai/deepseek-v3.2` has `cache_read_input_token_cost: null` — so the silent
  input-rate fallback kicks in.

## Change

- New **`pier/utils/pricing.py`** centralizes rate resolution and cost math.
  Resolution order:
  1. **`PIER_PRICING_FILE`** user overrides,
  2. **`litellm.model_cost`**,
  3. a small built-in **`SUPPLEMENTARY_PRICING`** table for models litellm doesn't
     yet ship (currently `deepseek-v4-pro`, `deepseek-v4-flash`), so cost is
     correct out of the box for known gaps.
- **Fail-loud:** when a run used cached tokens but no cache-read rate is known
  from any source, cost is left **unpriced (`cost_usd = null`) with an error
  log**, instead of a silently-inflated number. `PIER_PRICING_FALLBACK=input`
  restores the legacy approximate behavior.
- **`PIER_PRICING_FILE`** — JSON mapping model → rate fields (USD per token, same
  schema as `litellm.model_cost`), for pricing models litellm doesn't know,
  supplying a missing cache-read rate, or overriding any built-in/litellm entry:
  ```json
  {
    "deepseek-v4-pro": {
      "input_cost_per_token": 4.35e-7,
      "output_cost_per_token": 8.7e-7,
      "cache_read_input_token_cost": 3.625e-9
    }
  }
  ```
- Routes **all five cost paths** through the shared helper — `codex`,
  `gemini_cli`, `cursor_cli`, the viewer `/api/pricing` endpoint, and
  `mini_swe_agent` — removing the duplicated per-adapter logic. For
  `mini_swe_agent`, the cache-aware figure is recomputed post-run and **replaces
  the reported cost only when the model can be priced completely**; otherwise the
  reported cost is kept. The viewer now reports `cache_read = null` when unlisted
  rather than mirroring the input rate.
- README section documenting the above.

## Relationship to #4

#4 fixes the same #21 cost inflation, scoped to `mini_swe_agent` via a hardcoded
`_SUPPLEMENTARY_PRICING` table. This PR **generalizes and supersedes** that
approach: the deepseek rates move into the shared resolver's supplementary table
(thanks @dephnor — same rates), `mini_swe_agent` goes through the same helper as
the other agents, and the silent cache-miss fallback becomes fail-loud
everywhere with a user-overridable `PIER_PRICING_FILE`. Net result is one
centralized, override-able mechanism across all adapters instead of a per-adapter
table — so #4 can be closed in favor of this.

## Relationship to litellm pricing data

LiteLLM's `model_cost` table is the de-facto pricing source, but it lags reality:
new models (e.g. `deepseek-v4-pro`) are missing entirely, and existing entries
frequently omit `cache_read_input_token_cost`. **The long-term fix is upstreaming
accurate rates to litellm** (`model_prices_and_context_window.json`), and that
should still happen — the supplementary table and overrides are not a substitute
for it.

In the meantime, the supplementary defaults + `PIER_PRICING_FILE` make pier
resilient and self-sufficient:

- **Pre-empt / work around missing or wrong litellm data** — price a brand-new
  model, or supply a cache-read rate litellm hasn't merged yet, without waiting on
  a litellm release. Because overrides take precedence, you can also correct a
  known-incorrect entry locally and immediately, then drop the override once the
  upstream fix lands.
- **Ad-hoc per-provider / per-deployment adjustments** — override rates for a
  specific provider, promotional or negotiated/enterprise pricing, or a
  self-hosted/proxied endpoint whose costs differ from list — independent of what
  litellm ships and without patching it.

Net: the fail-loud default guarantees pier never *silently* reports a wrong cost,
and the overrides file gives operators a first-class way to make it *right* for
their own models and providers.

## Testing

Unit + integration + live end-to-end:

- **`tests/test_pricing.py`** (13) — discount math, fail-loud, fallback,
  overrides loading, supplementary-table resolution and precedence,
  provider-prefix stripping, bad-file handling.
- **`tests/test_pricing_integration.py`** (13) — drives the real adapter methods
  (`_compute_cost_from_pricing` for codex/gemini/mini-swe,
  `_resolve_pricing_rates` for cursor) and the viewer route via `TestClient`,
  including deepseek priced out of the box via the supplementary table.
- Full suite green; `ruff check`/`format` clean. (The only failures are the
  pre-existing `examples/hello-world` sandbox tests, which fail identically on
  `main`.)
- **Live, in Docker, end-to-end** — `codex` + OpenAI `gpt-5-mini` on hello-world,
  cost computed by this code *during* a real trial:

  | scenario | `cost_usd` | check |
  |---|---|---|
  | litellm cache-aware pricing | `$0.00524` | matches hand calc; cache billed at $0.025/M, not $0.25/M |
  | override missing cache rate | `null` + error log | fail-loud, no silent inflation |
  | `PIER_PRICING_FALLBACK=input` | `$0.00785` | legacy input-rate bill (≈50% higher on matched tokens) |

  Also verified a full Docker run via the `mini_swe_agent` path (reward 1.0) and
  the cache-aware recompute against its real token counts.

## Notes

- **Non-breaking:** `cost_usd` was already nullable; behavior changes only where a
  silently-inflated number was previously produced (and, for mini-swe-agent, where
  a complete cache-aware price is now available to replace a cache-blind one).

Refs #21, #19; supersedes #4. Thanks to @dephnor and the LayerLens analysis for
the original audit.
