### PR TITLE
fix: detect Claude Code compaction via top-level subtype

### DIFF
--- a/src/pier/agents/installed/claude_code.py
+++ b/src/pier/agents/installed/claude_code.py
@@ -35,6 +35,16 @@ from pier.utils.trajectory_metrics import (
 )
 
 
+def _is_compaction_boundary(event: dict[str, Any]) -> bool:
+    """Whether a Claude Code session event marks a context-compaction boundary.
+
+    Claude Code emits this as a top-level
+    ``{"type": "system", "subtype": "compact_boundary", ...}`` event (carrying a
+    top-level ``compactMetadata``), as seen in recent CC session artifacts.
+    """
+    return event.get("type") == "system" and event.get("subtype") == "compact_boundary"
+
+
 class ClaudeCode(BaseInstalledAgent):
     SUPPORTS_ATIF: bool = True
     memory_dir: str | None
@@ -1057,11 +1067,7 @@ class ClaudeCode(BaseInstalledAgent):
                 cache_read_seen = True
 
         summarization_count = sum(
-            1
-            for event in events
-            if event.get("type") == "system"
-            and isinstance(event.get("message"), dict)
-            and event["message"].get("subtype") == "compact_boundary"
+            1 for event in events if _is_compaction_boundary(event)
         )
 
         final_extra: dict[str, Any] | None = {}

--- a/tests/test_claude_code_compaction.py
+++ b/tests/test_claude_code_compaction.py
@@ -1,0 +1,21 @@
+from pier.agents.installed.claude_code import _is_compaction_boundary
+
+
+def test_top_level_compact_boundary_is_detected():
+    # Real Claude Code session artifacts emit the marker as a top-level subtype.
+    event = {
+        "type": "system",
+        "subtype": "compact_boundary",
+        "compactMetadata": {"trigger": "auto"},
+    }
+    assert _is_compaction_boundary(event) is True
+
+
+def test_non_compaction_system_events_are_ignored():
+    assert _is_compaction_boundary({"type": "system", "subtype": "init"}) is False
+    assert _is_compaction_boundary({"type": "system"}) is False
+    # Wrong event type, even with a matching subtype, is not a boundary.
+    assert (
+        _is_compaction_boundary({"type": "user", "subtype": "compact_boundary"})
+        is False
+    )


### PR DESCRIPTION
## Problem

The Claude Code trajectory converter counts context-compaction boundaries to set `summarization_count` / `compacted`, but it only matched a **nested** shape:

```python
event.get("type") == "system"
and isinstance(event.get("message"), dict)
and event["message"].get("subtype") == "compact_boundary"
```

Real Claude Code session artifacts (the `~/.claude/projects/**/*.jsonl` files this converter reads) emit the marker at the **top level**:

```json
{"type": "system", "subtype": "compact_boundary", "compactMetadata": {...}}
```

These system events have no `message` dict at all, so the predicate never matches: `summarization_count` stays `0` and `compacted` is never set on real trajectories — a silent false negative, and worst on the long-horizon rollouts where compaction actually happens.

## Fix

Detect the top-level `subtype` shape (extracted into a small `_is_compaction_boundary` helper) and add a focused regression test. Verified against the actual module — the real top-level event is now detected, whereas the previous nested-only logic returned `False` for it.

## Source

This bug was discovered and pointed out by Boxuan Li in Harbor: https://github.com/harbor-framework/harbor/pull/1888#discussion_r3411165245
