### PR TITLE
Add podman support (+ codex/opencode subscription auth under filtered egress)

### DIFF
--- a/src/pier/agents/installed/codex.py
+++ b/src/pier/agents/installed/codex.py
@@ -110,7 +110,13 @@ class Codex(BaseInstalledAgent):
                 parsed = {}
             urls.extend(collect_url_values(parsed))
 
-        return allowlist_from_urls(urls, default_domains=["api.openai.com"])
+        # api.openai.com serves OPENAI_API_KEY auth; chatgpt.com (the ChatGPT
+        # backend) and auth.openai.com (token refresh) serve ChatGPT-subscription
+        # auth via auth.json (CODEX_FORCE_AUTH_JSON / CODEX_AUTH_JSON_PATH).
+        return allowlist_from_urls(
+            urls,
+            default_domains=["api.openai.com", "chatgpt.com", "auth.openai.com"],
+        )
 
     def install_spec(self) -> AgentInstallSpec:
         version_spec = f"@{self._version}" if self._version else "@latest"

--- a/src/pier/agents/installed/opencode.py
+++ b/src/pier/agents/installed/opencode.py
@@ -2,6 +2,7 @@ import copy
 import json
 import shlex
 from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from pier.agents.installed.base import (
@@ -26,6 +27,7 @@ from pier.models.trajectories import (
     ToolCall,
     Trajectory,
 )
+from pier.utils.env import parse_bool_env_value
 from pier.utils.trajectory_metrics import (
     extra_with_context_metrics,
     peak_context_tokens_from_steps,
@@ -53,6 +55,7 @@ class OpenCode(BaseInstalledAgent):
     SUPPORTS_ATIF: bool = True
 
     _OUTPUT_FILENAME = "opencode.txt"
+    _REMOTE_XDG_DATA_HOME = PurePosixPath("/tmp/opencode-data")
     CLI_FLAGS = [
         CliFlag("variant", cli="--variant", type="str"),
     ]
@@ -70,7 +73,9 @@ class OpenCode(BaseInstalledAgent):
         "google": [".googleapis.com"],
         "groq": ["api.groq.com"],
         "mistral": ["api.mistral.ai"],
-        "openai": ["api.openai.com"],
+        # api.openai.com = API-key auth; chatgpt.com + auth.openai.com = the
+        # ChatGPT-subscription OAuth backend + token refresh (OPENCODE_FORCE_AUTH_JSON).
+        "openai": ["api.openai.com", "chatgpt.com", "auth.openai.com"],
         "openrouter": ["openrouter.ai"],
         "xai": ["api.x.ai"],
     }
@@ -452,6 +457,38 @@ class OpenCode(BaseInstalledAgent):
             default_domains=self._DEFAULT_PROVIDER_DOMAINS.get(provider, []),
         )
 
+    def _resolve_auth_json_path(self) -> Path | None:
+        """Resolve which opencode auth.json to inject, if any.
+
+        Defaults to None (env-var API-key auth). Opt into uploading the host's
+        opencode credentials -- which covers OAuth/subscription providers that
+        have no env-var key (e.g. ChatGPT-subscription openai for gpt-5.5) -- via:
+          - OPENCODE_AUTH_JSON_PATH=<path>  -> use that specific file
+          - OPENCODE_FORCE_AUTH_JSON=<truthy> -> use ~/.local/share/opencode/auth.json
+        """
+        explicit = self._get_env("OPENCODE_AUTH_JSON_PATH")
+        if explicit:
+            p = Path(explicit)
+            if not p.is_file():
+                raise ValueError(
+                    f"OPENCODE_AUTH_JSON_PATH points to non-existent file: {explicit}"
+                )
+            return p
+
+        if parse_bool_env_value(
+            self._get_env("OPENCODE_FORCE_AUTH_JSON"),
+            name="OPENCODE_FORCE_AUTH_JSON",
+            default=False,
+        ):
+            default = Path.home() / ".local" / "share" / "opencode" / "auth.json"
+            if not default.is_file():
+                raise ValueError(
+                    f"OPENCODE_FORCE_AUTH_JSON is set but {default} does not exist"
+                )
+            return default
+
+        return None
+
     @with_prompt_template
     async def run(
         self,
@@ -466,7 +503,34 @@ class OpenCode(BaseInstalledAgent):
 
         provider, _ = self.model_name.split("/", 1)
 
-        env = self.build_process_env()
+        # opencode reads credentials from $XDG_DATA_HOME/opencode/auth.json. Pin a
+        # fixed in-container data dir so we can optionally inject the host's
+        # auth.json for subscription/OAuth providers that have no env-var key.
+        remote_data_home = self._REMOTE_XDG_DATA_HOME.as_posix()
+        remote_auth_path = (
+            self._REMOTE_XDG_DATA_HOME / "opencode" / "auth.json"
+        ).as_posix()
+        env = self.build_process_env({"XDG_DATA_HOME": remote_data_home})
+
+        auth_json_path = self._resolve_auth_json_path()
+        if auth_json_path:
+            await self.exec_as_agent(
+                environment,
+                command="mkdir -p "
+                + shlex.quote((self._REMOTE_XDG_DATA_HOME / "opencode").as_posix()),
+                env=env,
+            )
+            await environment.upload_file(auth_json_path, remote_auth_path)
+            # docker cp lands the file root-owned; hand it to a non-root agent so
+            # it can read it. No-op on podman (cp already sets the container user)
+            # and skipped for root agents. cp preserves the host file's 0600 mode.
+            if environment.default_user is not None:
+                await self.exec_as_root(
+                    environment,
+                    command=f"chown {environment.default_user} "
+                    + shlex.quote(remote_auth_path),
+                )
+
         keys = []
 
         # Get provider environment variables

--- a/src/pier/environments/agent_setup.py
+++ b/src/pier/environments/agent_setup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import shlex
 from pathlib import Path
@@ -11,6 +12,14 @@ from pier.models.agent.network import NetworkAllowlist
 AGENT_INSTALL_DIR = ".pier-agent-install"
 EGRESS_PROXY_SERVICE = "pier-egress-proxy"
 EGRESS_PROXY_PORT = 8080
+
+
+def _docker_cmd() -> str:
+    return os.environ.get("PIER_DOCKER_CMD", "docker")
+
+
+def _is_podman() -> bool:
+    return os.path.basename(_docker_cmd()).startswith("podman")
 
 
 def docker_run_command(script: str) -> str:
@@ -193,6 +202,12 @@ def write_docker_proxy_compose(
             },
         },
     }
+    if _is_podman():
+        # podman-compose raises "missing networks: default" because the egress
+        # proxy service references ["pier-egress-internal", "default"] but only
+        # pier-egress-internal is declared top-level. Docker auto-creates the
+        # default network, so this is podman-only to keep docker output identical.
+        compose["networks"]["default"] = {}
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(compose, indent=2))
     return path

--- a/src/pier/environments/docker/__init__.py
+++ b/src/pier/environments/docker/__init__.py
@@ -14,6 +14,10 @@ RESOURCES_COMPOSE_NAME = "docker-compose-resources.json"
 
 
 def write_mounts_compose_file(path: Path, mounts: list[ServiceVolumeConfig]) -> Path:
+    # list(mounts) + json.dumps serializes every key in each mount dict verbatim,
+    # including an optional ``bind`` key ({"bind": {"selinux": "Z"}}) used for the
+    # podman :Z SELinux relabel on managed mounts. With no ``bind`` (the Docker
+    # path), output is byte-identical. No special-casing required.
     compose = {"services": {"main": {"volumes": list(mounts)}}}
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(compose, indent=2))

--- a/src/pier/environments/docker/docker.py
+++ b/src/pier/environments/docker/docker.py
@@ -38,6 +38,36 @@ from pier.models.trial.paths import EnvironmentPaths, TrialPaths
 from pier.utils.env import resolve_env_vars
 
 
+def _docker_cmd() -> str:
+    """Return the raw ``PIER_DOCKER_CMD`` value (default ``docker``).
+
+    ``PIER_DOCKER_CMD`` names the container *engine*: ``docker`` (default) or
+    ``podman``. Compose is always invoked as ``<engine> compose ...`` — mirroring
+    how the default ``docker`` already uses ``docker compose``. A trailing
+    ``-compose`` is tolerated (``podman-compose`` normalizes to ``podman`` via
+    :func:`_docker_engine`), so both ``podman`` and ``podman-compose`` work.
+    """
+    return os.environ.get("PIER_DOCKER_CMD", "docker")
+
+
+def _docker_engine() -> str:
+    """Return the container-engine binary (``docker`` or ``podman``).
+
+    Used both for native subcommands (``info``/``inspect``/``cp``/``ps``) and as
+    the prefix for ``<engine> compose ...``. A trailing ``-compose`` is stripped
+    so ``podman-compose`` -> ``podman`` and the default ``docker`` -> ``docker``.
+    """
+    base = os.path.basename(_docker_cmd())
+    if base.endswith("-compose"):
+        return base[: -len("-compose")]
+    return base
+
+
+def _is_podman() -> bool:
+    """True iff the configured engine is podman."""
+    return _docker_engine().startswith("podman")
+
+
 def _sanitize_docker_image_name(name: str) -> str:
     """
     Sanitize a name to be a valid Docker image name.
@@ -108,9 +138,11 @@ class DockerEnvironment(BaseEnvironment):
     @staticmethod
     def _detect_daemon_os() -> str | None:
         """Return the Docker daemon's OSType (e.g. 'linux' or 'windows'), or None on error."""
+        engine = _docker_engine()
+        fmt = "{{.Host.OS}}" if _is_podman() else "{{.OSType}}"
         try:
             result = subprocess.run(
-                ["docker", "info", "--format", "{{.OSType}}"],
+                [engine, "info", "--format", fmt],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -134,21 +166,23 @@ class DockerEnvironment(BaseEnvironment):
 
     @classmethod
     def preflight(cls) -> None:
-        if not shutil.which("docker"):
+        engine = _docker_engine()
+        label = "Podman" if _is_podman() else "Docker"
+        if not shutil.which(engine):
             raise SystemExit(
-                "Docker is not installed or not on PATH. "
-                "Please install Docker and try again."
+                f"{label} is not installed or not on PATH. "
+                f"Please install {label} and try again."
             )
         try:
             subprocess.run(
-                ["docker", "info"],
+                [engine, "info"],
                 capture_output=True,
                 timeout=10,
                 check=True,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             raise SystemExit(
-                "Docker daemon is not running. Please start Docker and try again."
+                f"{label} daemon is not running. Please start {label} and try again."
             )
 
     def __init__(
@@ -252,7 +286,7 @@ class DockerEnvironment(BaseEnvironment):
         return self._env_paths
 
     def _default_log_mounts(self) -> list[ServiceVolumeConfig]:
-        return [
+        mounts: list[ServiceVolumeConfig] = [
             {
                 "type": "bind",
                 "source": self.trial_paths.verifier_dir.resolve().as_posix(),
@@ -269,6 +303,13 @@ class DockerEnvironment(BaseEnvironment):
                 "target": str(self._env_paths.artifacts_dir),
             },
         ]
+        # podman + SELinux: relabel these Pier-managed bind mounts (:Z = private)
+        # so the container can write to them. User-supplied mounts are never
+        # auto-relabeled.
+        if _is_podman():
+            for mount in mounts:
+                mount["bind"] = {"selinux": "Z"}
+        return mounts
 
     @property
     def _uses_compose(self) -> bool:
@@ -473,14 +514,21 @@ class DockerEnvironment(BaseEnvironment):
         self, command: list[str], check: bool = True, timeout_sec: int | None = None
     ) -> ExecResult:
         """Run a docker compose command and return the result."""
+        project_name = _sanitize_docker_compose_project_name(self.session_id)
         full_command = [
-            "docker",
+            _docker_engine(),
             "compose",
             "--project-name",
-            _sanitize_docker_compose_project_name(self.session_id),
-            "--project-directory",
-            str(self.environment_dir.resolve().absolute()),
+            project_name,
         ]
+        if not _is_podman():
+            # podman's compose provider (podman-compose) rejects
+            # --project-directory; podman instead gets COMPOSE_PROJECT_DIR
+            # (honored by both providers) via the env dict injected below.
+            full_command += [
+                "--project-directory",
+                str(self.environment_dir.resolve().absolute()),
+            ]
         for path in self._docker_compose_paths:
             full_command.extend(["-f", str(path.resolve().absolute())])
         full_command.extend(command)
@@ -493,6 +541,17 @@ class DockerEnvironment(BaseEnvironment):
         # Inject after user env so it cannot be accidentally overridden.
         if self._windows_container_name:
             env["PIER_CONTAINER_NAME"] = self._windows_container_name
+        # podman's compose provider has no --project-directory flag;
+        # COMPOSE_PROJECT_DIR makes relative compose paths resolve from the
+        # environment dir.
+        if _is_podman():
+            env["COMPOSE_PROJECT_DIR"] = str(
+                self.environment_dir.resolve().absolute()
+            )
+            # `podman compose` prints an "Executing external compose provider"
+            # banner to stderr on every call; we merge stderr into stdout, so
+            # silence it to keep captured exec/cp output clean.
+            env["PODMAN_COMPOSE_WARNING_LOGS"] = "false"
 
         process = await asyncio.create_subprocess_exec(
             *full_command,
@@ -548,6 +607,13 @@ class DockerEnvironment(BaseEnvironment):
         vice versa), or when a Windows task is launched on a non-Windows
         host.
         """
+        if self._is_windows_container and _is_podman():
+            raise RuntimeError(
+                "Windows containers are not supported under podman "
+                "(PIER_DOCKER_CMD selects podman). "
+                "Use Docker for [environment].os = 'windows' tasks."
+            )
+
         if self._is_windows_container and sys.platform != "win32":
             raise RuntimeError(
                 "Task declares [environment].os = 'windows' but the host is "
@@ -580,7 +646,7 @@ class DockerEnvironment(BaseEnvironment):
         """
         try:
             result = await asyncio.create_subprocess_exec(
-                "docker",
+                _docker_engine(),
                 "inspect",
                 "--format",
                 "{{.Os}}",
@@ -653,7 +719,11 @@ class DockerEnvironment(BaseEnvironment):
         except RuntimeError:
             pass
 
-        await self._run_docker_compose_command(["up", "--detach", "--wait"])
+        up_command = ["up", "--detach", "--wait"]
+        if _is_podman():
+            # podman-compose's --wait can hang indefinitely; bound it.
+            up_command.append("--wait-timeout=300")
+        await self._run_docker_compose_command(up_command)
 
         # Make log directories world-writable so non-root agent/verifier
         # users can write to them.  (No-op for Windows containers which do
@@ -713,12 +783,101 @@ class DockerEnvironment(BaseEnvironment):
     async def upload_dir(self, source_dir: Path | str, target_dir: str):
         await self._platform.upload_dir(source_dir, target_dir)
 
+    async def _resolve_main_container_id(self) -> str:
+        """Return the single container id for the compose `main` service (podman).
+
+        Resolves by the docker-compatible compose labels (set by both the
+        podman-compose and docker-compose providers, so it is provider- and
+        container-name-separator-independent). Asserts exactly one match.
+        """
+        project_name = _sanitize_docker_compose_project_name(self.session_id)
+        proc = await asyncio.create_subprocess_exec(
+            _docker_engine(),
+            "ps",
+            "-q",
+            "--filter",
+            f"label=com.docker.compose.project={project_name}",
+            "--filter",
+            "label=com.docker.compose.service=main",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Failed to resolve 'main' container for project "
+                f"{project_name!r}: "
+                f"{(stderr_bytes or b'').decode(errors='replace')}"
+            )
+        ids = [
+            line.strip()
+            for line in (stdout_bytes or b"").decode(errors="replace").splitlines()
+            if line.strip()
+        ]
+        if len(ids) != 1:
+            raise RuntimeError(
+                f"Expected exactly one 'main' container for project "
+                f"{project_name!r}, found {len(ids)}: {ids}"
+            )
+        return ids[0]
+
+    async def _cp(self, source: str, dest: str, *, check: bool = True) -> ExecResult:
+        """Copy between host and container.
+
+        Docker defers to ``compose cp`` (service-addressed, e.g. ``main:/path``).
+        podman-compose has no usable ``cp``, so we resolve the ``main`` container
+        id by label and run native ``<engine> cp`` with that id substituted for
+        the ``main:`` service prefix.
+        """
+        if not _is_podman():
+            return await self._run_docker_compose_command(
+                ["cp", source, dest], check=check
+            )
+
+        container_id = await self._resolve_main_container_id()
+        native_source = (
+            f"{container_id}:{source[len('main:'):]}"
+            if source.startswith("main:")
+            else source
+        )
+        native_dest = (
+            f"{container_id}:{dest[len('main:'):]}"
+            if dest.startswith("main:")
+            else dest
+        )
+        proc = await asyncio.create_subprocess_exec(
+            _docker_engine(),
+            "cp",
+            native_source,
+            native_dest,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout_bytes, _ = await proc.communicate()
+        stdout = stdout_bytes.decode(errors="replace") if stdout_bytes else None
+        result = ExecResult(
+            stdout=stdout, stderr=None, return_code=proc.returncode or 0
+        )
+        if check and result.return_code != 0:
+            raise RuntimeError(
+                f"{_docker_engine()} cp failed "
+                f"({native_source} -> {native_dest}): "
+                f"return code {result.return_code}; {stdout}"
+            )
+        return result
+
     async def _chown_to_host_user(self, path: str, recursive: bool = False) -> None:
         """Best-effort chown of a container path to the host user's UID:GID.
 
         No-op on Windows (where os.getuid/os.getgid are unavailable).
         """
         if not hasattr(os, "getuid"):
+            return
+        if _is_podman():
+            # Rootless podman already maps the container's root user to the host
+            # user, so bind-mounted files are host-readable without chowning;
+            # chowning to the host uid here would instead map to an unreadable
+            # subuid. Skip under podman.
             return
         flag = "-R " if recursive else ""
         await self.exec(
@@ -743,6 +902,11 @@ class DockerEnvironment(BaseEnvironment):
         env = self._merge_env(env)
 
         exec_command = ["exec"]
+        if _is_podman():
+            # Captured exec: disable the pseudo-tty so output is plain and the
+            # call doesn't block on a TTY (docker's compose exec here is also
+            # non-interactive).
+            exec_command.append("-T")
 
         effective_cwd = cwd or self.task_env_config.workdir
         if effective_cwd:
@@ -768,10 +932,21 @@ class DockerEnvironment(BaseEnvironment):
                 "Interactive attach is not yet supported for Windows containers."
             )
 
-        variables = " ".join(
+        exports = [
             f"export {k}={shlex.quote(str(v))}"
             for k, v in self._env_vars.to_env_dict(include_os_env=False).items()
-        )
+        ]
+        if _is_podman():
+            # podman's compose provider has no --project-directory; pass the
+            # working dir via COMPOSE_PROJECT_DIR so the exec/down below resolve
+            # relative compose paths (mirrors _run_docker_compose_command).
+            # PODMAN_COMPOSE_WARNING_LOGS silences the provider banner.
+            exports.append(
+                "export COMPOSE_PROJECT_DIR="
+                + shlex.quote(str(self.environment_dir.resolve().absolute()))
+            )
+            exports.append("export PODMAN_COMPOSE_WARNING_LOGS=false")
+        variables = " ".join(exports)
 
         # Build the -f flags for docker compose
         compose_file_args = []
@@ -782,7 +957,7 @@ class DockerEnvironment(BaseEnvironment):
 
         project_name = _sanitize_docker_compose_project_name(self.session_id)
         compose_base = [
-            "docker",
+            _docker_engine(),
             "compose",
             "--project-name",
             project_name,
@@ -794,7 +969,14 @@ class DockerEnvironment(BaseEnvironment):
                 "bash",
                 "-c",
                 f"{variables}; "
-                + " ".join(compose_base + ["exec", "-it", "main", "bash"])
+                + " ".join(
+                    compose_base
+                    + (
+                        ["exec", "main", "bash"]
+                        if _is_podman()
+                        else ["exec", "-it", "main", "bash"]
+                    )
+                )
                 + "; "
                 + " ".join(compose_base + ["down"]),
             ],

--- a/src/pier/environments/docker/docker_unix.py
+++ b/src/pier/environments/docker/docker_unix.py
@@ -17,14 +17,16 @@ class UnixOps:
         self._env = env
 
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
-        await self._env._run_docker_compose_command(
-            ["cp", str(source_path), f"main:{target_path}"],
+        await self._env._cp(
+            str(source_path),
+            f"main:{target_path}",
             check=True,
         )
 
     async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
-        await self._env._run_docker_compose_command(
-            ["cp", f"{source_dir}/.", f"main:{target_dir}"],
+        await self._env._cp(
+            f"{source_dir}/.",
+            f"main:{target_dir}",
             check=True,
         )
         # Fix CRLF line endings when the host is Windows: shell scripts with
@@ -45,15 +47,17 @@ class UnixOps:
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         await self._env._chown_to_host_user(source_path)
-        await self._env._run_docker_compose_command(
-            ["cp", f"main:{source_path}", str(target_path)],
+        await self._env._cp(
+            f"main:{source_path}",
+            str(target_path),
             check=True,
         )
 
     async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
         await self._env._chown_to_host_user(source_dir, recursive=True)
-        await self._env._run_docker_compose_command(
-            ["cp", f"main:{source_dir}/.", str(target_dir)],
+        await self._env._cp(
+            f"main:{source_dir}/.",
+            str(target_dir),
             check=True,
         )
 

--- a/src/pier/models/trial/config.py
+++ b/src/pier/models/trial/config.py
@@ -22,6 +22,7 @@ from pier.utils.env import templatize_sensitive_env
 
 class ServiceVolumeBind(TypedDict):
     create_host_path: NotRequired[Literal[False]]
+    selinux: NotRequired[Literal["z", "Z"]]
 
 
 class ServiceVolumeVolume(TypedDict):

--- a/src/pier/trial/trial.py
+++ b/src/pier/trial/trial.py
@@ -19,6 +19,7 @@ from tenacity import (
 
 from pier.agents.installed.base import BaseInstalledAgent, NonZeroAgentExitCodeError
 from pier.environments.base import HealthcheckError
+from pier.environments.docker.docker import _is_podman
 from pier.environments.factory import EnvironmentFactory
 from pier.models.agent.context import AgentContext
 from pier.models.task.config import (
@@ -446,13 +447,20 @@ class Trial:
         env_config: TaskEnvironmentConfig,
     ) -> list[ServiceVolumeConfig]:
         env_paths = self._environment.env_paths.for_os(env_config.os)
-        return [
-            {
-                "type": "bind",
-                "source": self._trial_paths.verifier_dir.resolve().as_posix(),
-                "target": str(env_paths.verifier_dir),
-            }
-        ]
+        mount: ServiceVolumeConfig = {
+            "type": "bind",
+            "source": self._trial_paths.verifier_dir.resolve().as_posix(),
+            "target": str(env_paths.verifier_dir),
+        }
+        # podman + SELinux: relabel this Pier-managed bind mount (:Z = private) so
+        # the separate verifier container can write to it. The agent env already
+        # does this via DockerEnvironment._default_log_mounts(); this path passes
+        # mounts_json explicitly, which bypasses that helper, so the relabel must
+        # be applied here too. Without it the host dir keeps the agent container's
+        # MCS category and the verifier container is denied access. No-op on docker.
+        if _is_podman():
+            mount["bind"] = {"selinux": "Z"}
+        return [mount]
 
     def _verifier_env_build_context(self, step_cfg: StepConfig | None) -> Path:
         if step_cfg is not None:

--- a/tests/test_agent_subscription_auth.py
+++ b/tests/test_agent_subscription_auth.py
@@ -1,0 +1,69 @@
+"""Unit tests for installed-agent subscription / OAuth auth support.
+
+Covers the changes that let codex and opencode authenticate via a host
+auth.json (ChatGPT-subscription OAuth) under pier:
+  - the openai egress allowlist extended to the ChatGPT OAuth backend
+    (chatgpt.com) + token-refresh host (auth.openai.com), for both agents, and
+  - opencode's auth.json injection resolution (OPENCODE_FORCE_AUTH_JSON /
+    OPENCODE_AUTH_JSON_PATH); docker/default behavior (None) when unset.
+
+No container engine required: agents are built with __new__ and only the
+attributes the methods touch are set.
+"""
+
+
+def test_codex_openai_allowlist_includes_chatgpt(monkeypatch):
+    from pier.agents.installed.codex import Codex
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    c = Codex.__new__(Codex)
+    c._extra_env = {}
+    c._config_toml = None
+    domains = c.network_allowlist().domains
+    assert "api.openai.com" in domains  # API-key auth preserved
+    assert "chatgpt.com" in domains  # ChatGPT-subscription OAuth backend
+    assert "auth.openai.com" in domains  # OAuth token refresh
+
+
+def _opencode_agent():
+    from pier.agents.installed.opencode import OpenCode
+
+    oc = OpenCode.__new__(OpenCode)
+    oc._extra_env = {}
+    return oc
+
+
+def test_opencode_openai_allowlist_includes_chatgpt():
+    from pier.agents.installed.opencode import OpenCode
+
+    dom = OpenCode._DEFAULT_PROVIDER_DOMAINS["openai"]
+    assert "api.openai.com" in dom  # API-key auth preserved
+    assert "chatgpt.com" in dom  # ChatGPT-subscription OAuth backend
+    assert "auth.openai.com" in dom  # OAuth token refresh
+
+
+def test_opencode_resolve_auth_json_none_when_unset(monkeypatch):
+    monkeypatch.delenv("OPENCODE_AUTH_JSON_PATH", raising=False)
+    monkeypatch.delenv("OPENCODE_FORCE_AUTH_JSON", raising=False)
+    assert _opencode_agent()._resolve_auth_json_path() is None
+
+
+def test_opencode_resolve_auth_json_explicit_path(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENCODE_FORCE_AUTH_JSON", raising=False)
+    f = tmp_path / "auth.json"
+    f.write_text("{}")
+    monkeypatch.setenv("OPENCODE_AUTH_JSON_PATH", str(f))
+    assert _opencode_agent()._resolve_auth_json_path() == f
+
+
+def test_opencode_resolve_auth_json_force_uses_default_home(tmp_path, monkeypatch):
+    from pier.agents.installed import opencode as opencode_mod
+
+    monkeypatch.delenv("OPENCODE_AUTH_JSON_PATH", raising=False)
+    monkeypatch.setenv("OPENCODE_FORCE_AUTH_JSON", "1")
+    auth = tmp_path / ".local" / "share" / "opencode" / "auth.json"
+    auth.parent.mkdir(parents=True)
+    auth.write_text("{}")
+    monkeypatch.setattr(opencode_mod.Path, "home", lambda: tmp_path)
+    assert _opencode_agent()._resolve_auth_json_path() == auth

--- a/tests/test_podman_support.py
+++ b/tests/test_podman_support.py
@@ -1,0 +1,407 @@
+"""Unit tests for opt-in podman / podman-compose support (PIER_DOCKER_CMD).
+
+Each test asserts one of:
+  (a) docker behavior is byte-identical when PIER_DOCKER_CMD is unset, or
+  (b) the correct podman adaptation when it is set.
+No container engine is required: subprocess / compose calls are mocked, and
+DockerEnvironment is built with __new__ (only the attributes a method touches
+are set), mirroring tests/test_filtered_egress_env.py.
+"""
+
+import asyncio
+import functools
+import json
+
+import pytest
+
+from pier.environments import agent_setup
+from pier.environments.base import ExecResult
+from pier.environments.docker import docker as docker_mod
+from pier.environments.docker import write_mounts_compose_file
+from pier.environments.docker.docker import (
+    DockerEnvironment,
+    _docker_cmd,
+    _docker_engine,
+    _is_podman,
+)
+from pier.models.trial.paths import EnvironmentPaths
+
+
+def run_async(fn):
+    """Drive an async test with asyncio.run (pier has no pytest-asyncio)."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(fn(*args, **kwargs))
+
+    return wrapper
+
+
+# --------------------------------------------------------------------------
+# 1. Engine helpers
+# --------------------------------------------------------------------------
+def test_helpers_default_is_docker(monkeypatch):
+    monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    assert _docker_cmd() == "docker"
+    assert _is_podman() is False
+    assert _docker_engine() == "docker"
+
+
+def test_helpers_podman(monkeypatch):
+    # the documented value is the engine name
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman")
+    assert _docker_cmd() == "podman"
+    assert _is_podman() is True
+    assert _docker_engine() == "podman"
+    # a trailing -compose is tolerated and normalized to the engine, so the
+    # legacy `podman-compose` value still resolves to engine `podman`
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman-compose")
+    assert _is_podman() is True
+    assert _docker_engine() == "podman"
+
+
+def test_helpers_path_and_variant_forms(monkeypatch):
+    monkeypatch.setenv("PIER_DOCKER_CMD", "/usr/bin/podman")
+    assert _is_podman() is True
+    assert _docker_engine() == "podman"
+    # an absolute docker path must NOT be misclassified as podman
+    monkeypatch.setenv("PIER_DOCKER_CMD", "/usr/local/bin/docker")
+    assert _is_podman() is False
+    assert _docker_engine() == "docker"
+    # startswith("podman") intentionally catches podman-remote
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman-remote")
+    assert _is_podman() is True
+
+
+# --------------------------------------------------------------------------
+# 2. write_mounts_compose_file (the :Z carrier; docker byte-identical)
+# --------------------------------------------------------------------------
+def test_mounts_compose_docker_byte_identical(tmp_path):
+    mounts = [{"type": "bind", "source": "/h/v", "target": "/logs/verifier"}]
+    p = write_mounts_compose_file(tmp_path / "m.json", mounts)
+    expected = json.dumps({"services": {"main": {"volumes": mounts}}}, indent=2)
+    assert p.read_text() == expected
+
+
+def test_mounts_compose_serializes_selinux(tmp_path):
+    mounts = [
+        {
+            "type": "bind",
+            "source": "/h/v",
+            "target": "/logs/verifier",
+            "bind": {"selinux": "Z"},
+        }
+    ]
+    p = write_mounts_compose_file(tmp_path / "m.json", mounts)
+    vol = json.loads(p.read_text())["services"]["main"]["volumes"][0]
+    assert vol["bind"] == {"selinux": "Z"}
+
+
+# --------------------------------------------------------------------------
+# 3. Egress-proxy default network (podman-only; no docker leak)
+# --------------------------------------------------------------------------
+def _proxy_networks(monkeypatch, tmp_path, cmd):
+    if cmd is None:
+        monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    else:
+        monkeypatch.setenv("PIER_DOCKER_CMD", cmd)
+    allowlist = type("Allowlist", (), {"domains": ["api.openai.com"]})()
+    agent_setup.write_docker_proxy_compose(
+        path=tmp_path / "c.json",
+        proxy_dir=tmp_path / "proxy",
+        allowlist=allowlist,
+        token="secret",
+    )
+    return set(json.loads((tmp_path / "c.json").read_text())["networks"])
+
+
+def test_egress_default_network_podman(monkeypatch, tmp_path):
+    nets = _proxy_networks(monkeypatch, tmp_path, "podman")
+    assert nets == {"pier-egress-internal", "default"}
+
+
+def test_egress_no_default_network_docker(monkeypatch, tmp_path):
+    nets = _proxy_networks(monkeypatch, tmp_path, None)
+    assert nets == {"pier-egress-internal"}
+
+
+# --------------------------------------------------------------------------
+# 4. _default_log_mounts (:Z under podman; none under docker)
+# --------------------------------------------------------------------------
+def _env_with_paths(tmp_path):
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env.trial_paths = type(
+        "TP",
+        (),
+        {
+            "verifier_dir": tmp_path / "v",
+            "agent_dir": tmp_path / "a",
+            "artifacts_dir": tmp_path / "art",
+        },
+    )()
+    env._env_paths = EnvironmentPaths()
+    return env
+
+
+def test_default_log_mounts_podman_adds_selinux(monkeypatch, tmp_path):
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman")
+    mounts = _env_with_paths(tmp_path)._default_log_mounts()
+    assert len(mounts) == 3
+    assert all(m["bind"] == {"selinux": "Z"} for m in mounts)
+
+
+def test_default_log_mounts_docker_has_no_bind(monkeypatch, tmp_path):
+    monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    mounts = _env_with_paths(tmp_path)._default_log_mounts()
+    assert all("bind" not in m for m in mounts)
+
+
+# --------------------------------------------------------------------------
+# 4b. Trial._verifier_env_mounts (:Z under podman) — the separate-verifier-env
+#     mount path that bypasses _default_log_mounts. Regression guard for the
+#     SELinux fix that made the separate verifier env writable under podman.
+# --------------------------------------------------------------------------
+def _verifier_env_mounts(monkeypatch, tmp_path, cmd):
+    if cmd is None:
+        monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    else:
+        monkeypatch.setenv("PIER_DOCKER_CMD", cmd)
+    from pier.trial.trial import Trial
+
+    t = Trial.__new__(Trial)
+    t._environment = type(
+        "E",
+        (),
+        {"env_paths": type("EP", (), {"for_os": lambda self, _os: EnvironmentPaths()})()},
+    )()
+    t._trial_paths = type("TP", (), {"verifier_dir": tmp_path / "v"})()
+    return t._verifier_env_mounts(type("C", (), {"os": None})())
+
+
+def test_verifier_env_mounts_podman_adds_selinux(monkeypatch, tmp_path):
+    mounts = _verifier_env_mounts(monkeypatch, tmp_path, "podman")
+    assert len(mounts) == 1
+    assert mounts[0]["type"] == "bind"
+    assert mounts[0]["bind"] == {"selinux": "Z"}
+
+
+def test_verifier_env_mounts_docker_has_no_bind(monkeypatch, tmp_path):
+    mounts = _verifier_env_mounts(monkeypatch, tmp_path, None)
+    assert len(mounts) == 1
+    assert "bind" not in mounts[0]
+
+
+# --------------------------------------------------------------------------
+# 5. _cp dispatch (compose cp on docker; native cp on podman)
+# --------------------------------------------------------------------------
+@run_async
+async def test_cp_docker_uses_compose_cp(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env._run_docker_compose_command = AsyncMock(
+        return_value=ExecResult(return_code=0)
+    )
+    env._resolve_main_container_id = AsyncMock()
+    await env._cp("/h/x", "main:/c/x", check=True)
+    env._run_docker_compose_command.assert_awaited_once_with(
+        ["cp", "/h/x", "main:/c/x"], check=True
+    )
+    env._resolve_main_container_id.assert_not_awaited()
+
+
+@run_async
+async def test_cp_podman_uses_native_cp_with_prefix_rewrite(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman")
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env._resolve_main_container_id = AsyncMock(return_value="abc123")
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def fake_exec(*args, **kwargs):
+        captured["argv"] = args
+        return FakeProc()
+
+    monkeypatch.setattr(docker_mod.asyncio, "create_subprocess_exec", fake_exec)
+    # download direction: main: prefix on the source -> <id>:
+    await env._cp("main:/c/f", "/h/f", check=True)
+    assert captured["argv"] == ("podman", "cp", "abc123:/c/f", "/h/f")
+    # a host path that merely contains "main:" mid-string is NOT rewritten
+    await env._cp("/home/main:keep", "main:/c/g", check=True)
+    assert captured["argv"] == ("podman", "cp", "/home/main:keep", "abc123:/c/g")
+
+
+# --------------------------------------------------------------------------
+# 6. exec adds -T under podman only
+# --------------------------------------------------------------------------
+def _exec_env(monkeypatch, cmd):
+    if cmd is None:
+        monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    else:
+        monkeypatch.setenv("PIER_DOCKER_CMD", cmd)
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env._resolve_user = lambda u: None
+    env._merge_env = lambda e: None
+    env.task_env_config = type("T", (), {"workdir": None})()
+    env._platform = type(
+        "P", (), {"exec_shell_args": staticmethod(lambda c: ["bash", "-c", c])}
+    )()
+    captured = {}
+
+    async def fake_run(cmd_, check=False, timeout_sec=None):
+        captured["cmd"] = cmd_
+        return ExecResult(return_code=0)
+
+    env._run_docker_compose_command = fake_run
+    return env, captured
+
+
+@run_async
+async def test_exec_adds_T_under_podman(monkeypatch):
+    env, captured = _exec_env(monkeypatch, "podman")
+    await env.exec("true")
+    assert captured["cmd"][:2] == ["exec", "-T"]
+
+
+@run_async
+async def test_exec_no_T_under_docker(monkeypatch):
+    env, captured = _exec_env(monkeypatch, None)
+    await env.exec("true")
+    assert captured["cmd"][0] == "exec"
+    assert "-T" not in captured["cmd"]
+
+
+# --------------------------------------------------------------------------
+# 7. compose prefix: --project-directory (docker) vs COMPOSE_PROJECT_DIR (podman)
+# --------------------------------------------------------------------------
+def _compose_env(monkeypatch, tmp_path, cmd):
+    if cmd is None:
+        monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    else:
+        monkeypatch.setenv("PIER_DOCKER_CMD", cmd)
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env.session_id = "sess"
+    env.environment_dir = tmp_path
+    env._compose_task_env = {}
+    env._persistent_env = {}
+    env._windows_container_name = None
+    env._env_vars = type(
+        "EV", (), {"to_env_dict": lambda self, include_os_env=True: {}}
+    )()
+    monkeypatch.setattr(type(env), "_docker_compose_paths", property(lambda self: []))
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def fake_exec(*args, env=None, **kwargs):
+        captured["argv"] = list(args)
+        captured["env"] = env
+        return FakeProc()
+
+    monkeypatch.setattr(docker_mod.asyncio, "create_subprocess_exec", fake_exec)
+    return env, captured
+
+
+@run_async
+async def test_compose_prefix_podman(monkeypatch, tmp_path):
+    env, captured = _compose_env(monkeypatch, tmp_path, "podman")
+    await env._run_docker_compose_command(["up"])
+    argv = captured["argv"]
+    # symmetric with docker: `podman compose ...` (the `compose` subcommand)
+    assert argv[:2] == ["podman", "compose"]
+    # but no --project-directory (podman's provider rejects it); dir via env
+    assert "--project-directory" not in argv
+    assert captured["env"]["COMPOSE_PROJECT_DIR"] == str(
+        tmp_path.resolve().absolute()
+    )
+    # the provider banner is silenced so it can't pollute captured exec/cp output
+    assert captured["env"]["PODMAN_COMPOSE_WARNING_LOGS"] == "false"
+
+
+@run_async
+async def test_compose_prefix_podman_compose_value_normalizes(monkeypatch, tmp_path):
+    # the legacy `podman-compose` value resolves to the same `podman compose ...`
+    env, captured = _compose_env(monkeypatch, tmp_path, "podman-compose")
+    await env._run_docker_compose_command(["up"])
+    assert captured["argv"][:2] == ["podman", "compose"]
+
+
+@run_async
+async def test_compose_prefix_docker(monkeypatch, tmp_path):
+    env, captured = _compose_env(monkeypatch, tmp_path, None)
+    await env._run_docker_compose_command(["up"])
+    argv = captured["argv"]
+    assert argv[:2] == ["docker", "compose"]
+    assert "--project-directory" in argv
+    assert "COMPOSE_PROJECT_DIR" not in captured["env"]
+    assert "PODMAN_COMPOSE_WARNING_LOGS" not in captured["env"]
+
+
+# --------------------------------------------------------------------------
+# 8. Windows tasks rejected under podman
+# --------------------------------------------------------------------------
+def test_windows_rejected_under_podman(monkeypatch):
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman")
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env._is_windows_container = True
+    with pytest.raises(RuntimeError, match="not supported under podman"):
+        env._validate_daemon_mode()
+
+
+def test_windows_docker_does_not_raise_podman_message(monkeypatch):
+    monkeypatch.delenv("PIER_DOCKER_CMD", raising=False)
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env._is_windows_container = True
+    # On a non-win32 host this raises the existing host-mismatch error, NOT the
+    # podman one. (On win32 it would proceed; either way the podman message must
+    # never appear under docker.)
+    with pytest.raises(RuntimeError) as exc:
+        env._validate_daemon_mode()
+    assert "not supported under podman" not in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# 9. _resolve_main_container_id uses provider-independent compose labels
+# --------------------------------------------------------------------------
+@run_async
+async def test_resolve_main_container_id_uses_docker_labels(monkeypatch):
+    monkeypatch.setenv("PIER_DOCKER_CMD", "podman")
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env.session_id = "sess"
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"abc123\n", b"")
+
+    async def fake_exec(*args, **kwargs):
+        captured["argv"] = args
+        return FakeProc()
+
+    monkeypatch.setattr(docker_mod.asyncio, "create_subprocess_exec", fake_exec)
+    cid = await env._resolve_main_container_id()
+    assert cid == "abc123"
+    argv = captured["argv"]
+    assert argv[0] == "podman"
+    assert "ps" in argv and "-q" in argv
+    # the `com.docker.compose.*` labels are set by BOTH the podman-compose and
+    # docker-compose providers, so the lookup is provider-independent.
+    assert "label=com.docker.compose.project=sess" in argv
+    assert "label=com.docker.compose.service=main" in argv


### PR DESCRIPTION
Hi i really find pier a great project but wanted to run it with podman. This worked for me with podman and i didnt test it with docker itself. This code is vibecoded but i wanted to share it. Hope it helps.

Lets pier run its sandboxed agents on rootless podman (including SELinux Enforcing), and adds subscription auth for claude-code, codex, and opencode so no metered API key is needed. Everything is opt-in and gated — the docker path is untouched when off.

Usage

Needs podman + a compose provider (podman-compose, or podman compose which delegates to one). Rootless and SELinux Enforcing both work.

The only switch is the PIER_DOCKER_CMD env var. There's no separate "podman" environment type — pier keeps using its default docker environment, and this var tells it to drive that with the podman CLI. So you don't pass --env:

PIER_DOCKER_CMD=podman pier run -p path/to/task -a oracle
PIER_DOCKER_CMD=podman pier run -p path/to/task -a claude-code -m sonnet

Unset (or =docker) → unchanged docker behavior. A trailing -compose is tolerated, so podman and podman-compose both resolve to podman. SELinux :Z relabeling and the egress-proxy network are handled automatically.

Subscription / OAuth agent auth

The agent reads these from the environment (or --env-file / --ae):

# claude-code — Claude subscription token
CLAUDE_CODE_OAUTH_TOKEN=...  PIER_DOCKER_CMD=podman \
  pier run -p TASK -a claude-code -m sonnet

# codex — ChatGPT subscription (uploads ~/.codex/auth.json)
CODEX_FORCE_AUTH_JSON=1  PIER_DOCKER_CMD=podman \
  pier run -p TASK -a codex -m openai/gpt-5.5 --ak reasoning_effort=high

# opencode — ChatGPT/OAuth subscription (uploads ~/.local/share/opencode/auth.json)
OPENCODE_FORCE_AUTH_JSON=1  PIER_DOCKER_CMD=podman \
  pier run -p TASK -a opencode -m openai/gpt-5.5

Lets pier run its sandboxed agents on rootless podman (including SELinux Enforcing), and adds subscription auth for claude-code, codex, and opencode so no metered API key is needed. Everything is opt-in and gated — the docker path is untouched when off.

Usage

Needs podman + a compose provider (podman-compose, or podman compose which delegates to one). Rootless and SELinux Enforcing both work.

The only switch is the PIER_DOCKER_CMD env var. There's no separate "podman" environment type — pier keeps using its default docker environment, and this var tells it to drive that with the podman CLI. So you don't pass --env:

PIER_DOCKER_CMD=podman pier run -p path/to/task -a oracle
PIER_DOCKER_CMD=podman pier run -p path/to/task -a claude-code -m sonnet

▎ PIER_DOCKER_CMD defaults to docker, so if you don't set it, pier behaves exactly as it does today — the podman code paths only run when you set it to podman. (A trailing -compose is tolerated, so podman-compose resolves to podman too.)

Subscription / OAuth agent auth

The agent reads these from the environment (or --env-file / --ae):

# claude-code — Claude subscription token
CLAUDE_CODE_OAUTH_TOKEN=...  PIER_DOCKER_CMD=podman \
  pier run -p TASK -a claude-code -m sonnet

# codex — ChatGPT subscription (uploads ~/.codex/auth.json)
CODEX_FORCE_AUTH_JSON=1  PIER_DOCKER_CMD=podman \
  pier run -p TASK -a codex -m openai/gpt-5.5 --ak reasoning_effort=high

# opencode — ChatGPT/OAuth subscription (uploads ~/.local/share/opencode/auth.json)
OPENCODE_FORCE_AUTH_JSON=1  PIER_DOCKER_CMD=podman \
  pier run -p TASK -a opencode -m openai/gpt-5.5

On allow_internet=false tasks these route through pier's egress proxy, whose allowlist now covers the ChatGPT backend so subscription codex/opencode work under filtered egress.

What changed

Podman support — local DockerEnvironment only; compose invoked symmetrically as <engine> compose …. Each podman branch is gated (no-op on docker):
- --project-directory is docker-only; podman uses COMPOSE_PROJECT_DIR + PODMAN_COMPOSE_WARNING_LOGS=false
- no usable compose cp → resolve the main container by com.docker.compose.* labels + native <engine> cp
- exec -T; SELinux :Z on managed bind mounts, including the separate verifier environment (its mount bypassed the relabel → grader hit "permission denied" → RewardFileNotFoundError)
- egress-proxy default network; skip chown-to-host-uid (rootless maps container-root → host-user); info --format {{.Host.OS}}; reject Windows tasks; bound up --wait with --wait-timeout

codex — extend the openai egress allowlist to chatgpt.com + auth.openai.com, so the existing CODEX_FORCE_AUTH_JSON subscription path works under filtered egress (the ChatGPT backend isn't api.openai.com).

opencode — new OPENCODE_FORCE_AUTH_JSON / OPENCODE_AUTH_JSON_PATH inject the host auth.json via XDG_DATA_HOME, for OAuth/subscription providers that have no env-var key (e.g. gpt-5.5 via ChatGPT). Mirrors codex's CODEX_FORCE_AUTH_JSON; same allowlist extension.

Testing

26 unit tests (tests/test_podman_support.py, tests/test_agent_subscription_auth.py) — assert docker output is byte-identical when unset, plus every podman branch and the codex/opencode allowlist & auth resolution. End-to-end on podman 5.8.3 / podman-compose 1.6.0 (rootless, SELinux Enforcing): hello-world, filtered egress, and real DeepSWE tasks (oracle + claude-code/codex/opencode) — 0 infrastructure exceptions.

Caveat — only tested on podman: all runs used the podman CLI directly via PIER_DOCKER_CMD=podman; the default docker path was never executed (no Docker daemon on the dev box). It's preserved by construction (gated branches; unset = original command tokens) and the unit tests check it, but a real-Docker run (CI or a maintainer) should confirm before merge.

---Developed with Claude Code (https://claude.com/claude-code).