### PR TITLE
fix(job, viewer): JobStats.n_agent_steps report correctly agents step counts 

### DIFF
--- a/src/pier/models/job/result.py
+++ b/src/pier/models/job/result.py
@@ -32,6 +32,7 @@ class JobStats(BaseModel):
     n_pending_trials: int = 0
     n_cancelled_trials: int = 0
     n_retries: int = 0
+    n_agent_steps: int | None = None
     evals: dict[str, AgentDatasetStats] = Field(
         default_factory=lambda: defaultdict(AgentDatasetStats)
     )
@@ -168,6 +169,10 @@ class JobStats(BaseModel):
         if cost is not None:
             self.cost_usd = (self.cost_usd or 0.0) + cost
 
+        steps = trial_result.agent_step_count()
+        if steps is not None:
+            self.n_agent_steps = (self.n_agent_steps or 0) + steps
+
     def remove_trial(self, trial_result: TrialResult) -> None:
         """Remove a trial's contributions from stats."""
         self.n_completed_trials -= 1
@@ -211,6 +216,10 @@ class JobStats(BaseModel):
             self.n_output_tokens = max(0, self.n_output_tokens - n_output)
         if cost is not None and self.cost_usd is not None:
             self.cost_usd = max(0.0, self.cost_usd - cost)
+
+        steps = trial_result.agent_step_count()
+        if steps is not None and self.n_agent_steps is not None:
+            self.n_agent_steps = max(0, self.n_agent_steps - steps)
 
     def update_trial(
         self,

--- a/src/pier/viewer/server.py
+++ b/src/pier/viewer/server.py
@@ -1246,15 +1246,7 @@ def _register_job_endpoints(app: FastAPI, jobs_dir: Path) -> None:
                     environment_type = config.environment.type.value
 
             if result:
-                total_agent_steps: int | None = None
-                for trial_name in scanner.list_trials(name):
-                    trial_result = scanner.get_trial_result(name, trial_name)
-                    if trial_result is None:
-                        continue
-                    agent_steps = _agent_step_count_from_result(trial_result)
-                    if agent_steps is not None:
-                        total_agent_steps = (total_agent_steps or 0) + agent_steps
-
+                total_agent_steps = result.stats.n_agent_steps
                 # Extract evals from stats
                 evals = {
                     key: EvalSummary(metrics=eval_stats.metrics)

--- a/tests/test_job_stats.py
+++ b/tests/test_job_stats.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from uuid import uuid4
+
+from pier.models.job.result import JobStats
+from pier.models.trial.result import AgentInfo, TrialResult
+from pier.models.task.id import LocalTaskId
+from pier.models.trial.config import (
+    AgentConfig, EnvironmentConfig, 
+    TaskConfig, TrialConfig, VerifierConfig
+)
+from pier.models.agent.context import AgentContext
+
+
+def _make_trial_result(*, n_agent_steps: int | None = None, reward: float | None = None) -> TrialResult:
+    agent_result = AgentContext(n_agent_steps=n_agent_steps) if n_agent_steps is not None else None
+    return TrialResult(
+        id=uuid4(),
+        task_name="task",
+        trial_name="trial__abc",
+        trial_uri="file:///tmp/trial",
+        task_id=LocalTaskId(path=Path("/tmp/task")),
+        task_checksum="abc",
+        config=TrialConfig(
+            trial_name="trial__abc",
+            trials_dir=Path("/tmp"),
+            task=TaskConfig(path=Path("/tmp/task")),
+            agent=AgentConfig(name="oracle"),
+            environment=EnvironmentConfig(),
+            verifier=VerifierConfig(),
+        ),
+        agent_info=AgentInfo(name="oracle", version="1"),
+        agent_result=agent_result,
+    )
+
+
+def test_increment_increases_completed_count():
+    stats = JobStats()
+    stats.increment(_make_trial_result())
+    assert stats.n_completed_trials == 1
+
+
+def test_remove_trial_reverses_increment():
+    stats = JobStats()
+    trial = _make_trial_result()
+    stats.increment(trial)
+    stats.remove_trial(trial)
+    assert stats.n_completed_trials == 0
+
+
+def test_increment_accumulates_agent_steps():
+    stats = JobStats()
+    stats.increment(_make_trial_result(n_agent_steps=10))
+    stats.increment(_make_trial_result(n_agent_steps=5))
+    assert stats.n_agent_steps == 15
+
+
+def test_increment_skips_none_agent_steps():
+    stats = JobStats()
+    stats.increment(_make_trial_result(n_agent_steps=None))
+    assert stats.n_agent_steps is None
+
+
+def test_remove_trial_subtracts_agent_steps():
+    stats = JobStats()
+    trial = _make_trial_result(n_agent_steps=10)
+    stats.increment(trial)
+    stats.remove_trial(trial)
+    assert stats.n_agent_steps == 0
+
+
+def test_agent_steps_not_negative_after_remove():
+    stats = JobStats()
+    trial = _make_trial_result(n_agent_steps=3)
+    stats.increment(trial)
+    stats.remove_trial(trial)
+    stats.remove_trial(trial)  # double-remove should not go below 0
+    assert stats.n_agent_steps == 0
+
+
+def test_old_result_json_loads_without_agent_steps():
+    old_stats = {"n_completed_trials": 5, "n_errored_trials": 1}
+    stats = JobStats.model_validate(old_stats)
+    assert stats.n_agent_steps is None  # backward compat: field absent = None
+
+
+def test_increment_mixed_none_and_non_none_agent_steps():
+    stats = JobStats()
+    stats.increment(_make_trial_result(n_agent_steps=10))
+    stats.increment(_make_trial_result(n_agent_steps=None)) # Should not reset
+    stats.increment(_make_trial_result(n_agent_steps=5))
+    assert stats.n_agent_steps == 15
+
+
+def test_update_trial_replaces_agent_steps():
+    stats = JobStats()
+    original = _make_trial_result(n_agent_steps=10)
+    retry = _make_trial_result(n_agent_steps=4)
+    stats.increment(original)
+    stats.update_trial(retry, previous_result=original)
+    assert stats.n_agent_steps == 4


### PR DESCRIPTION
Fixes #13

## Summary
- Add `n_agent_steps: int | None` to `JobStats` and accumulate it in
  `increment()` / subtract it in `remove_trial()`, preserving None
  semantics when no trial reports steps
- Simplify the viewer's `total_agent_steps` logic in server.py to read
  the now-populated field directly
- Add `tests/test_job_stats.py` covering accumulation, None-skipping,
  removal, and mixed None/non-None trials

## Test plan
- `pytest tests/test_job_stats.py -v` — all 9 cases pass (see issue #13 for full output)
