### PR TITLE
Fix newline handling in dockerfile write to prevent CRLF issues on wi…

### DIFF
--- a/src/pier/environments/agent_setup.py
+++ b/src/pier/environments/agent_setup.py
@@ -73,7 +73,7 @@ def write_agent_dockerfile(
     )
     dockerfile.extend(dockerfile_install_commands(install, user=user))
     dockerfile.append("")
-    dockerfile_path.write_text("\n".join(dockerfile))
+    dockerfile_path.write_text("\n".join(dockerfile), newline="\n")
     return dockerfile_path
 
 


### PR DESCRIPTION
…ndows

On Windows, there is sometimes an error from CRLF line-endings in the generated Dockerfile because it is used in a bash environment.