### PR TITLE
Resume Codex sessions after transient capacity failures

### DIFF
--- a/src/pier/agents/installed/codex.py
+++ b/src/pier/agents/installed/codex.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import shlex
 from pathlib import Path, PurePosixPath
@@ -8,6 +9,7 @@ import toml
 from pier.agents.installed.base import (
     BaseInstalledAgent,
     CliFlag,
+    NonZeroAgentExitCodeError,
     with_prompt_template,
 )
 from pier.agents.network import allowlist_from_urls, collect_url_values
@@ -35,6 +37,44 @@ from pier.utils.trajectory_metrics import (
 from pier.utils.trajectory_utils import format_trajectory_json
 
 _COMPACTION_DROP_TOKEN_THRESHOLD = 10_000
+_MODEL_CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model."
+_MODEL_CAPACITY_RETRY_DELAYS = (30, 60, 120)
+
+
+def _iter_jsonl_events(output: str):
+    for line in output.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def _is_model_capacity_failure(output: str) -> bool:
+    for event in _iter_jsonl_events(output):
+        if (
+            event.get("type") == "error"
+            and event.get("message") == _MODEL_CAPACITY_MESSAGE
+        ):
+            return True
+        if event.get("type") == "turn.failed":
+            error = event.get("error")
+            if (
+                isinstance(error, dict)
+                and error.get("message") == _MODEL_CAPACITY_MESSAGE
+            ):
+                return True
+    return False
+
+
+def _root_thread_id(output: str) -> str | None:
+    for event in _iter_jsonl_events(output):
+        if event.get("type") == "thread.started":
+            thread_id = event.get("thread_id")
+            if isinstance(thread_id, str) and thread_id:
+                return thread_id
+    return None
 
 
 class Codex(BaseInstalledAgent):
@@ -1054,6 +1094,76 @@ class Codex(BaseInstalledAgent):
 
         return None
 
+    async def _run_with_capacity_resume(
+        self,
+        environment: BaseEnvironment,
+        initial_command: str,
+        resume_command_prefix: str,
+        env: dict[str, str],
+    ) -> None:
+        output_path = (EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME).as_posix()
+
+        try:
+            await self.exec_as_agent(environment, command=initial_command, env=env)
+            return
+        except NonZeroAgentExitCodeError as error:
+            last_error = error
+
+        tail_result = await self.exec_as_agent(
+            environment,
+            command=f"tail -n 20 {shlex.quote(output_path)} 2>/dev/null || true",
+            env=env,
+        )
+        if not _is_model_capacity_failure(tail_result.stdout or ""):
+            raise last_error
+
+        thread_result = await self.exec_as_agent(
+            environment,
+            command=f"head -n 100 {shlex.quote(output_path)} 2>/dev/null || true",
+            env=env,
+        )
+        thread_id = _root_thread_id(thread_result.stdout or "")
+        if thread_id is None:
+            raise last_error
+
+        continuation = shlex.quote(
+            "Continue the task from where you stopped. Verify the remaining work and "
+            "finish the task."
+        )
+        for attempt, delay in enumerate(_MODEL_CAPACITY_RETRY_DELAYS, start=1):
+            self.logger.warning(
+                "Codex model capacity failure; resuming root thread %s in %ss "
+                "(attempt %s/%s)",
+                thread_id,
+                delay,
+                attempt,
+                len(_MODEL_CAPACITY_RETRY_DELAYS),
+            )
+            await asyncio.sleep(delay)
+            try:
+                await self.exec_as_agent(
+                    environment,
+                    command=(
+                        f"{resume_command_prefix}{shlex.quote(thread_id)} "
+                        f"{continuation} 2>&1 </dev/null | tee -a "
+                        f"{shlex.quote(output_path)}"
+                    ),
+                    env=env,
+                )
+                return
+            except NonZeroAgentExitCodeError as error:
+                last_error = error
+
+            tail_result = await self.exec_as_agent(
+                environment,
+                command=f"tail -n 20 {shlex.quote(output_path)} 2>/dev/null || true",
+                env=env,
+            )
+            if not _is_model_capacity_failure(tail_result.stdout or ""):
+                raise last_error
+
+        raise last_error
+
     @with_prompt_template
     async def run(
         self, instruction: str, environment: BaseEnvironment, context: AgentContext
@@ -1145,24 +1255,29 @@ class Codex(BaseInstalledAgent):
                 command=setup_command,
                 env=env,
             )
+        codex_command_prefix = (
+            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; codex exec "
+        )
+        codex_options = (
+            "--dangerously-bypass-approvals-and-sandbox "
+            "--skip-git-repo-check "
+            f"--model {shlex.quote(model)} "
+            "--json "
+            "--enable unified_exec "
+            f"{cli_flags_arg}"
+        )
+        output_path = (EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME).as_posix()
+        initial_command = (
+            f"{codex_command_prefix}{codex_options}-- {escaped_instruction} "
+            f"2>&1 </dev/null | tee {shlex.quote(output_path)}"
+        )
+        resume_command_prefix = f"{codex_command_prefix}resume {codex_options}"
+
         try:
-            await self.exec_as_agent(
+            await self._run_with_capacity_resume(
                 environment,
-                command=(
-                    "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; "
-                    "codex exec "
-                    "--dangerously-bypass-approvals-and-sandbox "
-                    "--skip-git-repo-check "
-                    f"--model {model} "
-                    "--json "
-                    "--enable unified_exec "
-                    f"{cli_flags_arg}"
-                    "-- "  # end of flags
-                    f"{escaped_instruction} "
-                    f"2>&1 </dev/null | tee {
-                        EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME
-                    }"
-                ),
+                initial_command=initial_command,
+                resume_command_prefix=resume_command_prefix,
                 env=env,
             )
         finally:

--- a/tests/test_codex_capacity_resume.py
+++ b/tests/test_codex_capacity_resume.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pier.agents.installed.base import NonZeroAgentExitCodeError
+from pier.agents.installed.codex import (
+    Codex,
+    _is_model_capacity_failure,
+    _root_thread_id,
+)
+
+
+CAPACITY_EVENTS = """\
+{"type":"error","message":"Selected model is at capacity. Please try a different model."}
+{"type":"turn.failed","error":{"message":"Selected model is at capacity. Please try a different model."}}
+"""
+
+
+def test_detects_only_exact_model_capacity_errors():
+    assert _is_model_capacity_failure(CAPACITY_EVENTS)
+    assert not _is_model_capacity_failure(
+        '{"type":"turn.failed","error":{"message":"Authentication failed"}}'
+    )
+    assert not _is_model_capacity_failure("Selected model is at capacity")
+
+
+def test_root_thread_id_uses_first_started_thread():
+    output = "\n".join(
+        [
+            '{"type":"thread.started","thread_id":"root-thread"}',
+            '{"type":"thread.started","thread_id":"child-thread"}',
+        ]
+    )
+
+    assert _root_thread_id(output) == "root-thread"
+
+
+@pytest.mark.asyncio
+async def test_capacity_failure_resumes_root_thread(monkeypatch, tmp_path):
+    agent = Codex(logs_dir=tmp_path, model_name="openai/gpt-test")
+    agent.exec_as_agent = AsyncMock(
+        side_effect=[
+            NonZeroAgentExitCodeError("capacity"),
+            SimpleNamespace(stdout=CAPACITY_EVENTS),
+            SimpleNamespace(
+                stdout='{"type":"thread.started","thread_id":"root-thread"}\n'
+            ),
+            SimpleNamespace(stdout=""),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("pier.agents.installed.codex.asyncio.sleep", sleep)
+
+    await agent._run_with_capacity_resume(
+        environment=object(),
+        initial_command="codex exec initial",
+        resume_command_prefix="codex exec resume --json ",
+        env={"CODEX_HOME": "/tmp/codex-home"},
+    )
+
+    sleep.assert_awaited_once_with(30)
+    resume_command = agent.exec_as_agent.await_args_list[-1].kwargs["command"]
+    assert "codex exec resume --json root-thread" in resume_command
+    assert "tee -a /logs/agent/codex.txt" in resume_command
+    assert "--last" not in resume_command
+
+
+@pytest.mark.asyncio
+async def test_non_capacity_failure_is_not_retried(monkeypatch, tmp_path):
+    agent = Codex(logs_dir=tmp_path, model_name="openai/gpt-test")
+    failure = NonZeroAgentExitCodeError("failed")
+    agent.exec_as_agent = AsyncMock(
+        side_effect=[
+            failure,
+            SimpleNamespace(
+                stdout=(
+                    '{"type":"turn.failed","error":{"message":'
+                    '"Authentication failed"}}\n'
+                )
+            ),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("pier.agents.installed.codex.asyncio.sleep", sleep)
+
+    with pytest.raises(NonZeroAgentExitCodeError) as exc_info:
+        await agent._run_with_capacity_resume(
+            environment=object(),
+            initial_command="codex exec initial",
+            resume_command_prefix="codex exec resume --json ",
+            env={},
+        )
+
+    assert exc_info.value is failure
+    sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

- detect the exact transient Codex model-capacity failure in JSONL output
- preserve the current container and worktree, then resume the original root Codex thread with bounded backoff
- append resumed events to the same log and avoid `--last`, which may select a newer child-agent session
- leave authentication, tool, and other non-capacity failures unchanged

## Why

A long-running DRadar trial completed most of its implementation and validation work, then Codex returned `Selected model is at capacity. Please try a different model.` Pier propagated the non-zero exit immediately, so the trial was marked invalid and the completed agent work was lost.

This change retries only that exact transient failure and resumes the first `thread.started` ID from the existing log. It does not restart the whole trial or consume a new checkout.

## Tests

- `uv run ruff check src/pier/agents/installed/codex.py tests/test_codex_capacity_resume.py`
- `uv run pytest -q tests` (100 passed)
- `uv run pytest -q` reaches 100 passing tests; the two example hello-world tests fail outside their task container because `/app/hello.txt` is absent

Fixes #22
Related: SecurityMind/dradar#3
