### PR TITLE
fix: pin litellm proxy deps so mini-swe-agent quickstart works

### DIFF
--- a/src/pier/agents/installed/mini_swe_agent.py
+++ b/src/pier/agents/installed/mini_swe_agent.py
@@ -650,7 +650,7 @@ if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null;
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
 fi
 source "$HOME/.local/bin/env"
-uv tool install mini-swe-agent{version_spec}
+uv tool install mini-swe-agent{version_spec} --with 'litellm[proxy]'
 
 python_bin="$(head -n 1 "$(command -v mini-swe-agent)" | sed 's/^#!//')"
 {install_extra_packages}

--- a/tests/test_mini_swe_agent_install.py
+++ b/tests/test_mini_swe_agent_install.py
@@ -1,0 +1,53 @@
+import shlex
+from pathlib import Path
+
+from pier.agents.installed.mini_swe_agent import MiniSweAgent
+
+
+def _tool_install_command(agent: MiniSweAgent) -> str:
+    run_script = agent.install_spec().steps[-1].run
+    commands = [
+        line for line in run_script.splitlines() if line.startswith("uv tool install ")
+    ]
+
+    assert len(commands) == 1
+    return commands[0]
+
+
+def test_install_spec_provisions_litellm_proxy_dependencies(tmp_path: Path):
+    agent = MiniSweAgent(logs_dir=tmp_path, model_name="openai/gpt-5.5")
+
+    command = _tool_install_command(agent)
+
+    assert command == "uv tool install mini-swe-agent --with 'litellm[proxy]'"
+
+
+def test_install_spec_preserves_pinned_agent_version(tmp_path: Path):
+    agent = MiniSweAgent(
+        logs_dir=tmp_path,
+        model_name="openai/gpt-5.5",
+        version="2.2.8",
+    )
+
+    command = _tool_install_command(agent)
+
+    assert command == "uv tool install mini-swe-agent==2.2.8 --with 'litellm[proxy]'"
+
+
+def test_install_spec_without_extra_packages_is_valid_shell_command(tmp_path: Path):
+    agent = MiniSweAgent(
+        logs_dir=tmp_path,
+        model_name="openai/gpt-5.5",
+        extra_python_packages=[],
+    )
+
+    command = _tool_install_command(agent)
+
+    assert shlex.split(command) == [
+        "uv",
+        "tool",
+        "install",
+        "mini-swe-agent",
+        "--with",
+        "litellm[proxy]",
+    ]


### PR DESCRIPTION
## Summary
The mini-swe-agent quickstart installs the agent with `uv tool install mini-swe-agent`, but the agent needs the litellm proxy extras at runtime and they were not installed, so the quickstart failed. This adds `--with 'litellm[proxy]'` to the install so the proxy dependencies are present.

Closes #21
