### PR TITLE
fix: use a unique Modal egress-proxy sandbox name per retry attempt

### DIFF
--- a/src/pier/environments/modal.py
+++ b/src/pier/environments/modal.py
@@ -49,6 +49,9 @@ except ImportError:
 
 _MODAL_DEFAULT_CPU_REQUEST_CORES = 0.125
 _MODAL_DEFAULT_MEMORY_REQUEST_MB = 128
+_MODAL_SANDBOX_NAME_MAX_LENGTH = 64
+_MODAL_SANDBOX_NAME_SUFFIX_LENGTH = 8
+_MODAL_EGRESS_PROXY_NAME_SUFFIX = "-egress-proxy"
 
 
 class _ModalStrategy:
@@ -863,6 +866,7 @@ class ModalEnvironment(BaseEnvironment):
         self._image: Image | None = None
         self._app: App | None = None
         self._sandbox: Sandbox | None = None
+        self._sandbox_name_suffix = self._generate_sandbox_name_suffix()
         self._egress_proxy_sandbox: Sandbox | None = None
         self._egress_proxy_env: dict[str, str] = {}
         self._egress_cidr_allowlist: list[str] | None = None
@@ -886,6 +890,24 @@ class ModalEnvironment(BaseEnvironment):
         Alpine-based DinD images only have ``sh``; standard images have ``bash``.
         """
         return "sh" if self._compose_mode else "bash"
+
+    @staticmethod
+    def _generate_sandbox_name_suffix() -> str:
+        return uuid4().hex[:_MODAL_SANDBOX_NAME_SUFFIX_LENGTH]
+
+    @property
+    def _sandbox_name(self) -> str:
+        suffix = f"-{self._sandbox_name_suffix}"
+        max_session_length = (
+            _MODAL_SANDBOX_NAME_MAX_LENGTH
+            - len(suffix)
+            - len(_MODAL_EGRESS_PROXY_NAME_SUFFIX)
+        )
+        return f"{self.session_id[:max_session_length]}{suffix}"
+
+    @property
+    def _egress_proxy_sandbox_name(self) -> str:
+        return f"{self._sandbox_name}{_MODAL_EGRESS_PROXY_NAME_SUFFIX}"
 
     def _cpu_config(self) -> int | float | tuple[int | float, int] | None:
         """Resolve CPU configuration for sandbox creation.
@@ -1004,7 +1026,7 @@ class ModalEnvironment(BaseEnvironment):
             readiness_probe=modal.sandbox.Probe.with_tcp(EGRESS_PROXY_PORT),
             timeout=self._sandbox_timeout,
             idle_timeout=self._sandbox_idle_timeout,
-            name=f"{self.session_id}-egress-proxy",
+            name=self._egress_proxy_sandbox_name,
         )
         tunnel = (await self._egress_proxy_sandbox.tunnels.aio(timeout=60))[
             EGRESS_PROXY_PORT
@@ -1079,7 +1101,7 @@ class ModalEnvironment(BaseEnvironment):
             image=self._image,
             timeout=self._sandbox_timeout,
             idle_timeout=self._sandbox_idle_timeout,
-            name=self.session_id,
+            name=self._sandbox_name,
             block_network=block_network,
             cidr_allowlist=cidr_allowlist or self._egress_cidr_allowlist,
             secrets=self._secrets_config(),

--- a/tests/test_modal_egress_proxy_name.py
+++ b/tests/test_modal_egress_proxy_name.py
@@ -1,0 +1,45 @@
+import re
+
+from pier.environments.modal import ModalEnvironment
+
+
+def _modal_environment(session_id: str) -> ModalEnvironment:
+    env = ModalEnvironment.__new__(ModalEnvironment)
+    env.session_id = session_id
+    env._sandbox_name_suffix = env._generate_sandbox_name_suffix()
+    return env
+
+
+def test_retry_attempts_use_distinct_egress_proxy_names():
+    first_attempt = _modal_environment("task.session")
+    retry_attempt = _modal_environment("task.session")
+
+    assert first_attempt._egress_proxy_sandbox_name.startswith("task.session-")
+    assert retry_attempt._egress_proxy_sandbox_name.startswith("task.session-")
+    assert (
+        first_attempt._egress_proxy_sandbox_name
+        != retry_attempt._egress_proxy_sandbox_name
+    )
+
+
+def test_attempt_sandbox_names_are_related_and_valid_modal_identifiers():
+    env = _modal_environment(f"task.{'a' * 64}")
+
+    sandbox_name = env._sandbox_name
+    egress_proxy_name = env._egress_proxy_sandbox_name
+
+    assert egress_proxy_name == f"{sandbox_name}-egress-proxy"
+    assert sandbox_name != egress_proxy_name
+    assert sandbox_name.startswith("task.")
+    assert len(sandbox_name) <= 64
+    assert len(egress_proxy_name) <= 64
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", sandbox_name)
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", egress_proxy_name)
+
+
+def test_sandbox_name_suffixes_are_nonempty_and_unique_in_tight_loop():
+    suffixes = [ModalEnvironment._generate_sandbox_name_suffix() for _ in range(100)]
+
+    assert all(suffixes)
+    assert len(suffixes) == len(set(suffixes))
+    assert all(re.fullmatch(r"[0-9a-f]{8}", suffix) for suffix in suffixes)


### PR DESCRIPTION
## Summary
Modal egress-proxy sandboxes were created with a fixed name, so a retry that ran before the previous sandbox was fully torn down collided on the name and failed. This derives a unique egress-proxy sandbox name per retry attempt so retries no longer collide.

## Why this matters
The name collision turned a transient retry into a hard failure, defeating the retry logic exactly when it was needed.

## Testing
Exercised the retry path so a second attempt provisions a distinct proxy sandbox name instead of colliding with the first.

Closes #5
