### PR TITLE
fix(daytona): make network allowlist resolution robust to split-horizon launcher DNS

### DIFF
--- a/src/pier/environments/daytona.py
+++ b/src/pier/environments/daytona.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import asyncio
 import atexit
 import ipaddress
+import json
 import os
 import shlex
 import socket
 import tempfile
+import urllib.parse
+import urllib.request
 from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
@@ -112,6 +115,79 @@ def _cidrs_from_domain_resolution(
     )
 
 
+# Address space a cloud sandbox can never reach: answers in these ranges come from a
+# split-horizon (corporate/VPN) resolver's internal view of the domain, not the public
+# endpoint the sandbox will connect to. Shipping them in the allowlist silently blocks
+# every real connection.
+_SANDBOX_UNREACHABLE_NETS = tuple(
+    ipaddress.ip_network(net)
+    for net in (
+        "0.0.0.0/8",  # "this network"
+        "10.0.0.0/8",  # RFC1918
+        "100.64.0.0/10",  # CGNAT
+        "127.0.0.0/8",  # loopback
+        "169.254.0.0/16",  # link-local
+        "172.16.0.0/12",  # RFC1918
+        "192.168.0.0/16",  # RFC1918
+        "224.0.0.0/4",  # multicast
+        "240.0.0.0/4",  # reserved
+    )
+)
+
+# Public DNS-over-HTTPS resolvers used as a fallback when the local resolver returns no
+# sandbox-reachable answer for an allowlist domain (split-horizon DNS, or no A record in
+# the local view). Queried over plain HTTPS with the JSON API; no extra dependencies.
+_DOH_RESOLVER_URLS = (
+    "https://dns.google/resolve",
+    "https://cloudflare-dns.com/dns-query",
+)
+_DOH_TIMEOUT_SECONDS = 5.0
+_DNS_TYPE_A = 1
+
+
+def _is_sandbox_reachable_ipv4(addr: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    if ip.version != 4:
+        return False
+    return not any(ip in net for net in _SANDBOX_UNREACHABLE_NETS)
+
+
+def _resolve_domain_via_public_doh(domain: str) -> list[str]:
+    """Best-effort A-record lookup through public DNS-over-HTTPS resolvers.
+
+    Used only when the local resolver produced no sandbox-reachable answer, so a
+    launcher behind split-horizon DNS still allowlists the public addresses the
+    sandbox will actually connect to. Returns [] when every resolver fails.
+    """
+    for resolver_url in _DOH_RESOLVER_URLS:
+        query = urllib.parse.urlencode({"name": domain, "type": "A"})
+        request = urllib.request.Request(
+            f"{resolver_url}?{query}",
+            headers={"accept": "application/dns-json"},
+        )
+        try:
+            with urllib.request.urlopen(
+                request, timeout=_DOH_TIMEOUT_SECONDS
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except (OSError, ValueError):
+            continue
+        addrs = sorted(
+            {
+                answer.get("data", "")
+                for answer in payload.get("Answer") or []
+                if answer.get("type") == _DNS_TYPE_A
+                and _is_sandbox_reachable_ipv4(answer.get("data", ""))
+            }
+        )
+        if addrs:
+            return addrs
+    return []
+
+
 def resolve_network_allowlist_to_daytona_cidrs(
     domains: list[str],
 ) -> tuple[dict[str, list[str]], list[str]]:
@@ -119,13 +195,20 @@ def resolve_network_allowlist_to_daytona_cidrs(
 
     Daytona network limits accept IPv4 CIDR blocks only. Leading-dot suffix
     domains cannot be resolved deterministically, so they are ignored here.
+
+    Resolution runs on the LAUNCHER, but the allowlist gates the SANDBOX's
+    egress, so answers only the launcher's network can reach (split-horizon
+    corporate/VPN DNS returning private or CGNAT addresses) are dropped, and a
+    domain with no sandbox-reachable answer falls back to public DNS-over-HTTPS.
+    Without this, a launcher behind split-horizon DNS ships an allowlist of
+    internal addresses and the sandbox's every connection is silently blocked.
     """
     domain_resolution: dict[str, list[str]] = {}
     for domain in sorted(set(domains)):
         if domain.startswith("."):
             continue
         try:
-            addrs = sorted(
+            local_addrs = sorted(
                 {
                     info[4][0]
                     for info in socket.getaddrinfo(
@@ -137,7 +220,33 @@ def resolve_network_allowlist_to_daytona_cidrs(
                 }
             )
         except socket.gaierror:
-            addrs = []
+            local_addrs = []
+        addrs = [addr for addr in local_addrs if _is_sandbox_reachable_ipv4(addr)]
+        dropped = sorted(set(local_addrs) - set(addrs))
+        if dropped:
+            logger.warning(
+                "Ignoring local resolver answers for %s that a Daytona sandbox "
+                "cannot reach (split-horizon/corporate DNS?): %s",
+                domain,
+                ", ".join(dropped),
+            )
+        if not addrs:
+            addrs = _resolve_domain_via_public_doh(domain)
+            if addrs:
+                logger.warning(
+                    "Local resolver returned no sandbox-reachable IPv4 answer "
+                    "for %s; using public DNS-over-HTTPS answer instead: %s",
+                    domain,
+                    ", ".join(addrs),
+                )
+            else:
+                logger.warning(
+                    "Could not resolve any sandbox-reachable IPv4 address for "
+                    "allowlist domain %s (local resolver and public "
+                    "DNS-over-HTTPS both failed); connections to it from the "
+                    "sandbox will be blocked.",
+                    domain,
+                )
         domain_resolution[domain] = addrs
 
     return domain_resolution, _cidrs_from_domain_resolution(domain_resolution)

--- a/tests/test_daytona_network_limits.py
+++ b/tests/test_daytona_network_limits.py
@@ -1,6 +1,7 @@
+import asyncio
+import json
 import logging
 import socket
-import asyncio
 
 from pier.environments.daytona import (
     DAYTONA_MAX_NETWORK_ALLOWLIST_CIDRS,
@@ -42,6 +43,122 @@ def test_daytona_collapses_resolved_cidrs_to_daytona_limit(monkeypatch):
 
     assert len(cidrs) <= DAYTONA_MAX_NETWORK_ALLOWLIST_CIDRS
     assert all(cidr.endswith(("/32", "/31", "/30", "/29", "/28")) for cidr in cidrs)
+
+
+def test_daytona_drops_split_horizon_answers_but_keeps_public_ones(monkeypatch):
+    # A corporate/VPN resolver can return the INTERNAL view of a domain alongside
+    # (or instead of) the public one. Internal addresses gate nothing the sandbox
+    # can reach, so they must not consume allowlist entries.
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        return [_addr("10.1.2.3"), _addr("203.0.113.10"), _addr("192.168.7.7")]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    resolution, cidrs = resolve_network_allowlist_to_daytona_cidrs(
+        ["api.openai.com"]
+    )
+
+    assert resolution == {"api.openai.com": ["203.0.113.10"]}
+    assert cidrs == ["203.0.113.10/32"]
+
+
+def test_daytona_falls_back_to_public_doh_when_local_view_is_internal_only(
+    monkeypatch,
+):
+    # Split-horizon DNS (e.g. a corp devserver) resolves the model-API domain to
+    # internal VIPs only. The sandbox connects to the PUBLIC address, so the
+    # allowlist must come from a public resolver or every request is blocked.
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        return [_addr("10.1.2.3")]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "pier.environments.daytona._resolve_domain_via_public_doh",
+        lambda domain: ["203.0.113.10"],
+    )
+
+    resolution, cidrs = resolve_network_allowlist_to_daytona_cidrs(
+        ["api.openai.com"]
+    )
+
+    assert resolution == {"api.openai.com": ["203.0.113.10"]}
+    assert cidrs == ["203.0.113.10/32"]
+
+
+def test_daytona_falls_back_to_public_doh_on_local_resolution_failure(monkeypatch):
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        raise socket.gaierror("no such host in the local view")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "pier.environments.daytona._resolve_domain_via_public_doh",
+        lambda domain: ["203.0.113.10"],
+    )
+
+    resolution, cidrs = resolve_network_allowlist_to_daytona_cidrs(
+        ["api.openai.com"]
+    )
+
+    assert resolution == {"api.openai.com": ["203.0.113.10"]}
+    assert cidrs == ["203.0.113.10/32"]
+
+
+def test_daytona_resolution_empty_when_local_and_doh_both_fail(monkeypatch):
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        raise socket.gaierror("no such host in the local view")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "pier.environments.daytona._resolve_domain_via_public_doh",
+        lambda domain: [],
+    )
+
+    resolution, cidrs = resolve_network_allowlist_to_daytona_cidrs(
+        ["api.openai.com"]
+    )
+
+    assert resolution == {"api.openai.com": []}
+    assert cidrs == []
+
+
+def test_doh_parses_a_records_and_skips_unreachable_or_non_a(monkeypatch):
+    import io
+
+    from pier.environments.daytona import _resolve_domain_via_public_doh
+
+    payload = {
+        "Answer": [
+            {"type": 1, "data": "203.0.113.10"},
+            {"type": 1, "data": "10.9.9.9"},  # internal — must be skipped
+            {"type": 5, "data": "edge.example.net."},  # CNAME — must be skipped
+        ]
+    }
+
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_urlopen(request, timeout=None):
+        assert request.get_header("Accept") == "application/dns-json"
+        return FakeResponse(json.dumps(payload).encode("utf-8"))
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert _resolve_domain_via_public_doh("api.openai.com") == ["203.0.113.10"]
+
+
+def test_doh_returns_empty_when_all_resolvers_fail(monkeypatch):
+    from pier.environments.daytona import _resolve_domain_via_public_doh
+
+    def fake_urlopen(_request, timeout=None):
+        raise OSError("blocked")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert _resolve_domain_via_public_doh("api.openai.com") == []
 
 
 def test_daytona_network_params_use_resolved_allowlist(monkeypatch):


### PR DESCRIPTION
## Problem

`resolve_network_allowlist_to_daytona_cidrs` resolves allowlist domains with the **launcher's** resolver (`socket.getaddrinfo`), but the resulting IPv4 CIDRs gate the **sandbox's** egress. On a launcher behind split-horizon corporate/VPN DNS, the local answer for a public API domain is an internal VIP (RFC1918/CGNAT) — or there's no A record in the internal view at all. Either way, the sandbox's connections to the real public address are not in the allowlist, so **every** connection to that domain is silently blocked.

Observed in production: `deep-swe` evals (air-gapped tasks whose `NetworkAllowlist` opens exactly the model-API host) launched from a corporate devserver failed **all 113 tasks × all retries** with `transport error: error sending request for url (https://…/v1/responses)`, while the byte-identical command run from a MacBook (public DNS view) passed. Nothing in the logs pointed at DNS; the failure looks like a provider outage.

## Fix

Three layered changes in `resolve_network_allowlist_to_daytona_cidrs`, no new dependencies:

1. **Drop local answers a cloud sandbox can never reach** — RFC1918, CGNAT (100.64/10), loopback, link-local, multicast, reserved — with a warning naming the likely split-horizon cause. (Documentation/TEST-NET ranges are intentionally not filtered; they never occur in real answers and the existing test fixtures use them.)
2. **Fall back to public DNS-over-HTTPS** (dns.google, then cloudflare-dns.com — plain HTTPS JSON API via stdlib `urllib`) when a domain has no sandbox-reachable answer left, so a split-horizon launcher still allowlists the public addresses the sandbox will actually connect to.
3. **Warn explicitly when both paths fail** for a domain, instead of silently shipping an allowlist that blocks it.

Behavior on launchers with a normal public DNS view is unchanged: local answers are already sandbox-reachable, so the filter is a no-op and DoH is never queried.

## Tests

`tests/test_daytona_network_limits.py` (new, alongside the existing resolution tests):
- internal answers mixed with public ones → internal dropped, public kept
- internal-only local view → public DoH answer used
- local `gaierror` → public DoH answer used
- local + DoH both fail → empty resolution (existing `network_block_all` path takes over)
- DoH JSON parsing: keeps A records, skips CNAMEs and internal addresses; sends `accept: application/dns-json`
- DoH resolver errors → `[]`

`uv run pytest tests/` → 100 passed.
