### PR TITLE
Support [[verifier.collect]] hooks from task.toml

### DIFF
--- a/src/pier/models/task/config.py
+++ b/src/pier/models/task/config.py
@@ -81,16 +81,31 @@ class PackageInfo(BaseModel):
 
 MAIN_SERVICE_NAME = "main"
 
+_COMPOSE_SERVICE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def _validate_compose_service_name(value: str | None) -> str | None:
+    if value is None:
+        return value
+    value = value.strip()
+    if not _COMPOSE_SERVICE_NAME_PATTERN.match(value):
+        raise ValueError(
+            f"Invalid Docker Compose service name: {value!r}. Service names "
+            "must start with an alphanumeric character and contain only "
+            "alphanumeric characters, hyphens, underscores, and dots."
+        )
+    return value
+
 
 class VerifierCollectConfig(BaseModel):
-    """A command run in the agent environment after the agent phase ends.
+    """A command run inside a compose service after the agent phase ends.
 
-    Collect hooks let tasks snapshot runtime state into files before
-    verification, so artifact entries can transfer them (e.g. capture the
-    agent's change set as ``/logs/artifacts/model.patch`` for a separate
-    verifier). Mirrors Harbor's ``[[verifier.collect]]`` blocks. Pier only
-    supports hooks targeting the main service; hooks targeting compose
-    sidecar services are skipped with a warning.
+    Collect hooks let tasks snapshot runtime state into files before the
+    environment is torn down, so the files can be declared as artifacts and
+    read by a separate verifier (e.g. capture the agent's change set as
+    ``/logs/artifacts/model.patch``). Mirrors Harbor's ``[[verifier.collect]]``
+    blocks. Pier only runs hooks targeting the main service; hooks targeting
+    compose sidecar services are skipped with a warning.
     """
 
     command: str = Field(..., description="Shell command to run in the service.")
@@ -108,6 +123,14 @@ class VerifierCollectConfig(BaseModel):
         description="Username or UID to run the command as. None uses the "
         "service container's default user.",
     )
+
+    @field_validator("service")
+    @classmethod
+    def _validate_service(cls, value: str) -> str:
+        validated = _validate_compose_service_name(value)
+        if validated is None:
+            raise ValueError("Collect hook service must not be empty.")
+        return validated
 
 
 class VerifierConfig(BaseModel):

--- a/src/pier/models/task/config.py
+++ b/src/pier/models/task/config.py
@@ -79,6 +79,37 @@ class PackageInfo(BaseModel):
         return self.name.split("/")[1]
 
 
+MAIN_SERVICE_NAME = "main"
+
+
+class VerifierCollectConfig(BaseModel):
+    """A command run in the agent environment after the agent phase ends.
+
+    Collect hooks let tasks snapshot runtime state into files before
+    verification, so artifact entries can transfer them (e.g. capture the
+    agent's change set as ``/logs/artifacts/model.patch`` for a separate
+    verifier). Mirrors Harbor's ``[[verifier.collect]]`` blocks. Pier only
+    supports hooks targeting the main service; hooks targeting compose
+    sidecar services are skipped with a warning.
+    """
+
+    command: str = Field(..., description="Shell command to run in the service.")
+    service: str = Field(
+        default=MAIN_SERVICE_NAME,
+        description="Compose service to run the command in. Defaults to main. "
+        "Pier only runs hooks targeting main (the agent's container).",
+    )
+    timeout_sec: float = Field(
+        default=60.0,
+        description="Timeout in seconds for the collect command.",
+    )
+    user: str | int | None = Field(
+        default=None,
+        description="Username or UID to run the command as. None uses the "
+        "service container's default user.",
+    )
+
+
 class VerifierConfig(BaseModel):
     timeout_sec: float = 600.0
     env: dict[str, str] = Field(default_factory=dict)
@@ -104,6 +135,15 @@ class VerifierConfig(BaseModel):
             "environment_mode='separate'. When unset with "
             "environment_mode='separate', a fresh copy of the top-level "
             "[environment] is used. Conflicts with environment_mode='shared'."
+        ),
+    )
+    collect: list[VerifierCollectConfig] = Field(
+        default_factory=list,
+        description=(
+            "Commands run in the agent environment after the agent phase ends "
+            "and before artifact collection ([[verifier.collect]] blocks in "
+            "task.toml). Use these to snapshot runtime state into files that "
+            "artifact entries can then collect."
         ),
     )
 

--- a/src/pier/trial/trial.py
+++ b/src/pier/trial/trial.py
@@ -25,6 +25,7 @@ from pier.models.task.config import (
     EnvironmentConfig as TaskEnvironmentConfig,
 )
 from pier.models.task.config import (
+    MAIN_SERVICE_NAME,
     MultiStepRewardStrategy,
     StepConfig,
     VerifierEnvironmentMode,
@@ -742,6 +743,7 @@ class Trial:
                 )
                 self._maybe_populate_agent_context(step_result.agent_result)
                 await self._run_pre_artifacts_script()
+                await self._run_collect_hooks(step_cfg)
                 await self._maybe_upload_agent_logs()
 
                 # Collect artifacts from the agent environment before
@@ -842,6 +844,43 @@ class Trial:
                 "pre_artifacts.sh failed to run; continuing without it",
                 exc_info=True,
             )
+
+    async def _run_collect_hooks(self, step_cfg: StepConfig | None = None) -> None:
+        """Run the task's ``[[verifier.collect]]`` hooks in the agent environment.
+
+        Hooks run after the agent finishes and immediately before artifact
+        collection so the task can materialize artifacts from the agent's work
+        (e.g. capture the change set as ``/logs/artifacts/model.patch`` for a
+        separate verifier). Failures are logged, not fatal: a missing or failed
+        capture simply yields no artifact, which downstream grading treats as
+        an empty submission. Hooks targeting a compose service other than main
+        are skipped: Pier does not run commands in sidecar services.
+        """
+        hooks = list(self._task.config.verifier.collect)
+        if step_cfg is not None:
+            hooks.extend(step_cfg.verifier.collect)
+        for hook in hooks:
+            if hook.service != MAIN_SERVICE_NAME:
+                self._logger.warning(
+                    f"Skipping collect hook targeting unsupported service "
+                    f"'{hook.service}': {hook.command!r}"
+                )
+                continue
+            try:
+                result = await self._environment.exec(
+                    command=hook.command,
+                    timeout_sec=int(hook.timeout_sec),
+                    user=hook.user,
+                )
+                if result.return_code != 0:
+                    self._logger.warning(
+                        f"Collect hook {hook.command!r} exited {result.return_code}"
+                    )
+            except Exception:
+                self._logger.warning(
+                    f"Collect hook {hook.command!r} failed to run; continuing",
+                    exc_info=True,
+                )
 
     async def _maybe_upload_agent_logs(self) -> None:
         """Upload locally-generated agent logs back to the environment.
@@ -948,6 +987,7 @@ class Trial:
             # trials collect artifacts per-step inside _run_steps.
             if not self._task.has_steps:
                 await self._run_pre_artifacts_script()
+                await self._run_collect_hooks()
                 await self._maybe_upload_agent_logs()
                 await self._collect_artifacts()
 

--- a/src/pier/trial/trial.py
+++ b/src/pier/trial/trial.py
@@ -866,6 +866,9 @@ class Trial:
                     f"'{hook.service}': {hook.command!r}"
                 )
                 continue
+            self._logger.debug(
+                f"Running collect hook in service '{hook.service}': {hook.command!r}"
+            )
             try:
                 result = await self._environment.exec(
                     command=hook.command,
@@ -874,12 +877,18 @@ class Trial:
                 )
                 if result.return_code != 0:
                     self._logger.warning(
-                        f"Collect hook {hook.command!r} exited {result.return_code}"
+                        f"Collect hook in service '{hook.service}' exited with "
+                        f"code {result.return_code}: {hook.command!r}. "
+                        f"stdout: {result.stdout} stderr: {result.stderr}"
                     )
-            except Exception:
+                else:
+                    self._logger.debug(
+                        f"Collect hook in service '{hook.service}' completed"
+                    )
+            except Exception as exc:
                 self._logger.warning(
-                    f"Collect hook {hook.command!r} failed to run; continuing",
-                    exc_info=True,
+                    f"Collect hook in service '{hook.service}' failed "
+                    f"({hook.command!r}): {exc}"
                 )
 
     async def _maybe_upload_agent_logs(self) -> None:

--- a/tests/test_trial_collect_hooks.py
+++ b/tests/test_trial_collect_hooks.py
@@ -1,0 +1,96 @@
+"""Tests for the optional ``[[verifier.collect]]`` task hooks.
+
+Collect hooks run inside the agent environment after the agent finishes and
+immediately before artifact collection, so tasks can materialize artifacts
+(e.g. capture the agent's change set as /logs/artifacts/model.patch for a
+separate verifier).
+"""
+
+import asyncio
+import functools
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from pier.models.task.config import StepConfig, VerifierCollectConfig, VerifierConfig
+from pier.trial.trial import Trial
+
+
+def run_async(fn):
+    """Drive an async test with asyncio.run (pier has no pytest-asyncio)."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(fn(*args, **kwargs))
+
+    return wrapper
+
+
+def _fake_trial(hooks: list[VerifierCollectConfig]) -> SimpleNamespace:
+    environment = AsyncMock()
+    environment.exec.return_value = SimpleNamespace(return_code=0)
+    return SimpleNamespace(
+        _task=SimpleNamespace(
+            config=SimpleNamespace(verifier=VerifierConfig(collect=hooks))
+        ),
+        _environment=environment,
+        _logger=logging.getLogger(__name__),
+    )
+
+
+@run_async
+async def test_no_hooks_is_a_noop() -> None:
+    trial = _fake_trial([])
+    await Trial._run_collect_hooks(trial)
+    trial._environment.exec.assert_not_awaited()
+
+
+@run_async
+async def test_hook_is_executed() -> None:
+    hook = VerifierCollectConfig(
+        command="echo hi > /logs/artifacts/out.txt",
+        timeout_sec=120.0,
+        user="root",
+    )
+    trial = _fake_trial([hook])
+    await Trial._run_collect_hooks(trial)
+    trial._environment.exec.assert_awaited_once_with(
+        command="echo hi > /logs/artifacts/out.txt",
+        timeout_sec=120,
+        user="root",
+    )
+
+
+@run_async
+async def test_step_hooks_run_after_task_hooks() -> None:
+    task_hook = VerifierCollectConfig(command="task-hook")
+    step_hook = VerifierCollectConfig(command="step-hook")
+    trial = _fake_trial([task_hook])
+    step_cfg = StepConfig(name="grade", verifier=VerifierConfig(collect=[step_hook]))
+    await Trial._run_collect_hooks(trial, step_cfg)
+    commands = [
+        call.kwargs["command"] for call in trial._environment.exec.await_args_list
+    ]
+    assert commands == ["task-hook", "step-hook"]
+
+
+@run_async
+async def test_sidecar_hook_is_skipped() -> None:
+    hook = VerifierCollectConfig(command="pg_dump app", service="postgres")
+    trial = _fake_trial([hook])
+    await Trial._run_collect_hooks(trial)
+    trial._environment.exec.assert_not_awaited()
+
+
+@run_async
+async def test_nonzero_exit_does_not_raise() -> None:
+    trial = _fake_trial([VerifierCollectConfig(command="exit 3")])
+    trial._environment.exec.return_value = SimpleNamespace(return_code=3)
+    await Trial._run_collect_hooks(trial)  # must not raise
+
+
+@run_async
+async def test_exec_exception_is_swallowed() -> None:
+    trial = _fake_trial([VerifierCollectConfig(command="boom")])
+    trial._environment.exec.side_effect = RuntimeError("env died")
+    await Trial._run_collect_hooks(trial)  # must not raise


### PR DESCRIPTION
Adds support for Harbor's `[[verifier.collect]]` blocks in `task.toml`: commands run in the agent environment after the agent phase ends and immediately before artifact collection, so tasks can snapshot runtime state into files that artifact entries then collect (e.g. capture the agent's change set as `/logs/artifacts/model.patch` for a separate verifier).

- Adds `VerifierCollectConfig` (`command`, `service`, `timeout_sec`, `user`) and a `collect` list on `VerifierConfig`.
- Runs hooks in both single-step and multi-step trials, right after the existing `pre_artifacts.sh` hook; step-level hooks run after task-level hooks.
- Failures are logged and non-fatal, matching `pre_artifacts.sh` semantics.
- Hooks targeting a compose service other than `main` are skipped with a warning, since Pier does not run commands in sidecar services.

`pre_artifacts.sh` continues to work unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/datacurve-ai/pier/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->