### PR TITLE
Support Harbor-style network_mode in task.toml

### DIFF
--- a/src/pier/models/task/config.py
+++ b/src/pier/models/task/config.py
@@ -27,6 +27,53 @@ class VerifierEnvironmentMode(str, Enum):
     SEPARATE = "separate"
 
 
+class NetworkMode(str, Enum):
+    """Network access policy for agent and verifier execution.
+
+    Mirrors Harbor's ``NetworkMode`` (harbor.models.task.config): tasks authored
+    against Harbor >= 0.18 declare network policy via ``network_mode`` (at
+    [environment] scope, with optional [agent]/[verifier] phase overrides)
+    instead of the legacy ``allow_internet`` boolean. Values must stay in sync
+    with Harbor so the same task.toml parses identically in both harnesses.
+    """
+
+    NO_NETWORK = "no-network"
+    PUBLIC = "public"
+    ALLOWLIST = "allowlist"
+
+
+class NetworkPolicyFieldsMixin(BaseModel):
+    """``network_mode`` field shared by the [environment] scope and the
+    [agent]/[verifier] phase overrides (Harbor's PhaseNetworkPolicyConfig
+    equivalent). Pier currently enforces 'no-network' and 'public' only;
+    'allowlist' (and its 'allowed_hosts' companion) is rejected at parse time
+    rather than silently mis-enforced."""
+
+    network_mode: NetworkMode | None = Field(
+        default=None,
+        description="Network access policy ('no-network' or 'public'). On "
+        "[agent]/[verifier] this is an explicit phase override; on "
+        "[environment] it applies to both phases. When unset everywhere, the "
+        "legacy 'allow_internet' boolean applies.",
+    )
+    allowed_hosts: list[str] | None = Field(
+        default=None,
+        description="Unsupported (Harbor allowlist-mode companion field); "
+        "declared only so its presence fails loudly instead of being ignored.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_network_policy(self) -> "NetworkPolicyFieldsMixin":
+        if self.network_mode == NetworkMode.ALLOWLIST:
+            raise ValueError(
+                "network_mode='allowlist' is not supported by pier yet; "
+                "use 'no-network' or 'public'."
+            )
+        if self.allowed_hosts is not None:
+            raise ValueError("allowed_hosts is not supported by pier yet.")
+        return self
+
+
 class Author(BaseModel):
     """Author information for a package or dataset."""
 
@@ -133,7 +180,7 @@ class VerifierCollectConfig(BaseModel):
         return validated
 
 
-class VerifierConfig(BaseModel):
+class VerifierConfig(NetworkPolicyFieldsMixin):
     timeout_sec: float = 600.0
     env: dict[str, str] = Field(default_factory=dict)
     user: str | int | None = Field(
@@ -188,7 +235,7 @@ class SolutionConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
 
 
-class AgentConfig(BaseModel):
+class AgentConfig(NetworkPolicyFieldsMixin):
     timeout_sec: float | None = None
     user: str | int | None = Field(
         default=None,
@@ -227,7 +274,7 @@ class HealthcheckConfig(BaseModel):
     )
 
 
-class EnvironmentConfig(BaseModel):
+class EnvironmentConfig(NetworkPolicyFieldsMixin):
     build_timeout_sec: float = 600.0  # 10 minutes default
     docker_image: str | None = None
     os: TaskOS = Field(
@@ -248,7 +295,10 @@ class EnvironmentConfig(BaseModel):
     )
     allow_internet: bool = Field(
         default=True,
-        description="Whether to allow internet access in the environment.",
+        description="Whether to allow internet access in the environment. "
+        "Legacy boolean: when 'network_mode' is set (here or as an "
+        "[agent]/[verifier] phase override), the resolved mode wins and this "
+        "field is overwritten at TaskConfig validation time.",
     )
     mcp_servers: list["MCPServerConfig"] = Field(default_factory=list)
     env: dict[str, str] = Field(
@@ -449,6 +499,60 @@ class TaskConfig(BaseModel):
         if isinstance(data, dict) and "version" in data:
             data.setdefault("schema_version", data.pop("version"))
         return data
+
+    @model_validator(mode="after")
+    def resolve_network_modes(self) -> "TaskConfig":
+        """Resolve Harbor-style ``network_mode`` declarations onto the legacy
+        ``allow_internet`` booleans that pier's environments enforce.
+
+        Precedence per phase (mirrors Harbor): explicit [agent]/[verifier]
+        override > [environment] scope > legacy ``allow_internet``. 'public'
+        maps to allow_internet=True; 'no-network' to allow_internet=False.
+
+        Before this resolution existed, pier silently IGNORED network_mode and
+        fell back to allow_internet's default of True.
+        """
+        task_mode = self.environment.network_mode
+
+        agent_mode = self.agent.network_mode or task_mode
+        if agent_mode is not None:
+            self.environment.network_mode = agent_mode
+            self.environment.allow_internet = agent_mode == NetworkMode.PUBLIC
+
+        def _resolve_verifier(verifier: VerifierConfig) -> None:
+            mode = verifier.network_mode or task_mode
+            if mode is None:
+                return
+            if (
+                verifier.environment is None
+                and verifier.network_mode is not None
+                and verifier.environment_mode == VerifierEnvironmentMode.SEPARATE
+            ):
+                # An explicit [verifier] override with environment_mode =
+                # 'separate' but no spelled-out [verifier.environment] would be
+                # lost when the runtime materializes the fresh copy — do it now.
+                verifier.environment = self.environment.model_copy(deep=True)
+            if verifier.environment is not None:
+                verifier.environment.network_mode = mode
+                verifier.environment.allow_internet = mode == NetworkMode.PUBLIC
+            elif (
+                verifier.network_mode is not None
+                and agent_mode is not None
+                and verifier.network_mode != agent_mode
+            ):
+                # Shared-environment verifier: it runs in the agent's container,
+                # so a conflicting explicit override cannot be enforced.
+                raise ValueError(
+                    "[verifier].network_mode conflicts with the agent "
+                    "environment's resolved network policy but the verifier "
+                    "shares that environment; use environment_mode='separate' "
+                    "to give the verifier its own network policy."
+                )
+
+        _resolve_verifier(self.verifier)
+        for step in self.steps or []:
+            _resolve_verifier(step.verifier)
+        return self
 
     @classmethod
     def model_validate_toml(cls, toml_data: str) -> "TaskConfig":

--- a/tests/test_task_network_mode.py
+++ b/tests/test_task_network_mode.py
@@ -1,0 +1,139 @@
+"""network_mode (Harbor >= 0.18 schema) must resolve onto allow_internet.
+
+Regression tests for the air-gap escape where pier silently ignored
+``network_mode = "no-network"`` and defaulted to allow_internet=True.
+Scope: 'no-network' and 'public' only; 'allowlist'/'allowed_hosts' are
+rejected at parse time rather than silently mis-enforced.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from pier.models.task.config import NetworkMode, TaskConfig
+
+V11_STYLE = """
+schema_version = "1.3"
+[verifier]
+network_mode = "no-network"
+environment_mode = "separate"
+timeout_sec = 1800.0
+[verifier.environment]
+build_timeout_sec = 1800.0
+[agent]
+network_mode = "no-network"
+timeout_sec = 5400.0
+[environment]
+docker_image = "example/image:tag"
+"""
+
+
+def test_v11_no_network_resolves_to_no_internet():
+    cfg = TaskConfig.model_validate_toml(V11_STYLE)
+    assert cfg.environment.allow_internet is False
+    assert cfg.environment.network_mode is NetworkMode.NO_NETWORK
+    assert cfg.verifier.environment is not None
+    assert cfg.verifier.environment.allow_internet is False
+
+
+def test_public_mode_allows_internet():
+    cfg = TaskConfig.model_validate_toml("[environment]\nnetwork_mode = \"public\"\n")
+    assert cfg.environment.allow_internet is True
+
+
+def test_task_wide_mode_applies_to_explicit_verifier_environment():
+    cfg = TaskConfig.model_validate_toml(
+        """
+[verifier]
+environment_mode = "separate"
+[verifier.environment]
+docker_image = "example/verifier:tag"
+[environment]
+network_mode = "no-network"
+docker_image = "example/image:tag"
+"""
+    )
+    assert cfg.environment.allow_internet is False
+    assert cfg.verifier.environment.allow_internet is False
+
+
+def test_step_verifier_inherits_task_wide_mode():
+    cfg = TaskConfig.model_validate_toml(
+        """
+[environment]
+network_mode = "no-network"
+docker_image = "example/image:tag"
+[[steps]]
+name = "one"
+[steps.verifier]
+environment_mode = "separate"
+[steps.verifier.environment]
+docker_image = "example/verifier:tag"
+"""
+    )
+    assert cfg.steps[0].verifier.environment.allow_internet is False
+
+
+def test_agent_override_beats_environment_scope():
+    cfg = TaskConfig.model_validate_toml(
+        """
+[agent]
+network_mode = "no-network"
+[environment]
+network_mode = "public"
+"""
+    )
+    assert cfg.environment.allow_internet is False
+
+
+def test_shared_verifier_conflicting_override_rejected():
+    with pytest.raises(ValidationError):
+        TaskConfig.model_validate_toml(
+            """
+[agent]
+network_mode = "no-network"
+[verifier]
+network_mode = "public"
+[environment]
+docker_image = "example/image:tag"
+"""
+        )
+
+
+def test_separate_verifier_override_materializes_environment():
+    cfg = TaskConfig.model_validate_toml(
+        """
+[verifier]
+network_mode = "no-network"
+environment_mode = "separate"
+[environment]
+network_mode = "public"
+docker_image = "example/image:tag"
+"""
+    )
+    assert cfg.environment.allow_internet is True
+    assert cfg.verifier.environment is not None
+    assert cfg.verifier.environment.allow_internet is False
+
+
+def test_legacy_allow_internet_still_honored():
+    cfg = TaskConfig.model_validate_toml("[environment]\nallow_internet = false\n")
+    assert cfg.environment.allow_internet is False
+    cfg = TaskConfig.model_validate_toml("[environment]\n")
+    assert cfg.environment.allow_internet is True  # unchanged legacy default
+
+
+def test_allowlist_mode_rejected():
+    with pytest.raises(ValidationError):
+        TaskConfig.model_validate_toml("[agent]\nnetwork_mode = \"allowlist\"\n")
+
+
+def test_allowed_hosts_rejected():
+    with pytest.raises(ValidationError):
+        TaskConfig.model_validate_toml(
+            "[agent]\nnetwork_mode = \"no-network\"\nallowed_hosts = [\"a.com\"]\n"
+        )
+
+
+def test_unknown_network_mode_rejected():
+    with pytest.raises(ValidationError):
+        TaskConfig.model_validate_toml("[agent]\nnetwork_mode = \"offline\"\n")


### PR DESCRIPTION
Support the Harbor ≥ 0.18 `network_mode` task.toml key.

- Resolve `network_mode` (`no-network`/`public`) onto `allow_internet`; phase override > `[environment]` scope > legacy boolean.
- Reject `allowlist`/`allowed_hosts` at parse time (unsupported).
- 11 regression tests.