### PR TITLE
Add grok-build installed agent (SpaceXAI Grok Build CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pier is a fork. We wanted a smaller, more opinionated base to build on. On top o
 
 - **Task format:** Harbor-compatible.
 - **Environments:** `docker`, `modal`. Per-agent install specs and network allowlists are honored on both, so installed agents work under `allow_internet = false`.
-- **Agents:** `nop`, `oracle`, `antigravity-sdk`, `claude-code`, `codex`, `cursor-cli`, `gemini-cli`, `opencode`, `mini-swe-agent`. All emit augmented ATIF v1.7.
+- **Agents:** `nop`, `oracle`, `antigravity-sdk`, `claude-code`, `codex`, `cursor-cli`, `gemini-cli`, `grok-build`, `opencode`, `mini-swe-agent`. All emit augmented ATIF v1.7.
 - **Datasets:** local Harbor-format task directories via `-p` / `--path`.
 - **CLI:** `pier run`, `pier job`, `pier view`, `pier critique run`, `pier check` / `pier analyze` (vendored from Harbor)
 
@@ -130,6 +130,17 @@ through your env file.
   model_name: cursor/composer-2.5
   env:
     CURSOR_API_KEY: ${CURSOR_API_KEY}
+```
+
+**Grok Build** (xAI's `grok` CLI) authenticates with `XAI_API_KEY` when set; otherwise it copies a Grok CLI session file (kwarg `auth_file`, default `~/.grok/auth.json` — create it with `grok login` on the host) into the container's `GROK_HOME`. Model ids accept an optional provider prefix (`xai/grok-4.6` ≡ `grok-4.6`); omit `model_name` to use the CLI's default. Available model ids can differ between credentials and auth modes — check `grok models` under the credential you plan to run with. Kwargs: `reasoning_effort` (`low`–`xhigh`), `max_turns`, `disable_web_search` (default on), `no_plan` (default on), `no_subagents`.
+
+```yaml
+- name: grok-build
+  model_name: grok-4.6
+  kwargs:
+    reasoning_effort: xhigh
+  env:
+    XAI_API_KEY: ${XAI_API_KEY}
 ```
 
 **OpenCode** uses `opencode_config` to add unknown providers or override known ones. To redirect Google to Respan, override just `options.baseURL`; to add a fully custom provider, use `opencode_config.provider.<name>` with the npm package, options, and models.

--- a/src/pier/agents/factory.py
+++ b/src/pier/agents/factory.py
@@ -7,6 +7,7 @@ from pier.agents.installed.claude_code import ClaudeCode
 from pier.agents.installed.codex import Codex
 from pier.agents.installed.cursor_cli import CursorCli
 from pier.agents.installed.gemini_cli import GeminiCli
+from pier.agents.installed.grok_build import GrokBuild
 from pier.agents.installed.mini_swe_agent import MiniSweAgent
 from pier.agents.installed.opencode import OpenCode
 from pier.agents.nop import NopAgent
@@ -25,6 +26,7 @@ class AgentFactory:
         Codex,
         CursorCli,
         GeminiCli,
+        GrokBuild,
         MiniSweAgent,
         OpenCode,
     ]

--- a/src/pier/agents/installed/claude_code.py
+++ b/src/pier/agents/installed/claude_code.py
@@ -49,6 +49,8 @@ class ClaudeCode(BaseInstalledAgent):
     SUPPORTS_ATIF: bool = True
     memory_dir: str | None
 
+    _OUTPUT_FILENAME = "claude-code.txt"
+
     CLI_FLAGS = [
         CliFlag(
             "max_turns",
@@ -672,27 +674,37 @@ class ClaudeCode(BaseInstalledAgent):
         flush()
         return result
 
-    def _parse_total_cost_from_stream_json(self) -> float | None:
-        """Extract authoritative `total_cost_usd` from Claude Code's stdout stream.
+    def _iter_stream_events(self):
+        """Yield parsed JSON events from the teed stdout stream.
 
-        Claude Code's `--output-format=stream-json --print` mode emits a final
-        ``{"type":"result", ..., "total_cost_usd": <float>, ...}`` line to stdout,
-        which Pier tees to ``<logs_dir>/claude-code.txt``. Returns ``None`` if
-        the file is missing, malformed, or the result event lacks the field.
+        Skips blank/non-JSON lines. Decode errors are replaced rather than
+        raised (the agent can be killed mid-write), and an OSError — missing
+        file included — simply ends the stream.
         """
-        stream_path = self.logs_dir / "claude-code.txt"
+        stream_path = self.logs_dir / self._OUTPUT_FILENAME
         try:
-            content = stream_path.read_text(encoding="utf-8")
+            with open(stream_path, "r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line or not line.startswith("{"):
+                        continue
+                    try:
+                        yield json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
         except OSError:
-            return None
-        for line in content.splitlines():
-            line = line.strip()
-            if not line or not line.startswith("{"):
-                continue
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+            return
+
+    def _parse_total_cost_from_stream_json(self) -> float | None:
+        """Extract authoritative `total_cost_usd` from the CLI's stdout stream.
+
+        The `--output-format=stream-json --print` mode emits a final
+        ``{"type":"result", ..., "total_cost_usd": <float>, ...}`` line to
+        stdout, which Pier tees to ``<logs_dir>/<_OUTPUT_FILENAME>``. Returns
+        ``None`` if the file is missing, malformed, or the result event lacks
+        the field.
+        """
+        for event in self._iter_stream_events():
             if event.get("type") == "result":
                 cost = event.get("total_cost_usd")
                 if cost is None:
@@ -728,6 +740,12 @@ class ClaudeCode(BaseInstalledAgent):
         if not raw_events:
             return None
 
+        return self._convert_raw_events_to_trajectory(raw_events, session_dir.name)
+
+    def _convert_raw_events_to_trajectory(
+        self, raw_events: list[dict[str, Any]], fallback_session_id: str
+    ) -> Trajectory | None:
+        """Convert already-loaded session events into an ATIF trajectory."""
         raw_events.sort(key=lambda e: e.get("timestamp", ""))
         events = [event for event in raw_events if event.get("isSidechain")] + [
             event for event in raw_events if not event.get("isSidechain")
@@ -735,7 +753,7 @@ class ClaudeCode(BaseInstalledAgent):
         if not events:
             return None
 
-        session_id: str = session_dir.name
+        session_id: str = fallback_session_id
         for event in events:
             sid = event.get("sessionId")
             if isinstance(sid, str):
@@ -748,6 +766,11 @@ class ClaudeCode(BaseInstalledAgent):
             if isinstance(ver, str) and ver:
                 agent_version = ver
                 break
+        if agent_version == "unknown":
+            # _version is the constructor pin or post-install detection; the
+            # installers install exact pinned versions (or fail the setup),
+            # so this reflects the installed build for practical purposes.
+            agent_version = self.version() or agent_version
 
         cwds = {
             event.get("cwd")
@@ -1100,7 +1123,7 @@ class ClaudeCode(BaseInstalledAgent):
             schema_version="ATIF-v1.7",
             session_id=session_id,
             agent=Agent(
-                name=AgentName.CLAUDE_CODE.value,
+                name=self.name(),
                 version=agent_version,
                 model_name=default_model_name,
                 extra=agent_extra,
@@ -1110,6 +1133,23 @@ class ClaudeCode(BaseInstalledAgent):
         )
 
         return trajectory
+
+    def _write_trajectory(self, trajectory: Trajectory, context: AgentContext) -> None:
+        """Persist the trajectory to logs_dir and propagate final metrics."""
+        trajectory_path = self.logs_dir / "trajectory.json"
+        try:
+            with open(trajectory_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    trajectory.to_json_dict(), handle, indent=2, ensure_ascii=False
+                )
+            self.logger.debug(f"Wrote {self.name()} trajectory to {trajectory_path}")
+        except OSError as exc:
+            self.logger.debug(
+                f"Failed to write trajectory file {trajectory_path}: {exc}"
+            )
+
+        if trajectory.final_metrics:
+            populate_context_from_final_metrics(context, trajectory.final_metrics)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         session_dir = self._get_session_dir()
@@ -1128,20 +1168,7 @@ class ClaudeCode(BaseInstalledAgent):
             self.logger.debug("Failed to convert Claude Code session to trajectory")
             return
 
-        trajectory_path = self.logs_dir / "trajectory.json"
-        try:
-            with open(trajectory_path, "w", encoding="utf-8") as handle:
-                json.dump(
-                    trajectory.to_json_dict(), handle, indent=2, ensure_ascii=False
-                )
-            self.logger.debug(f"Wrote Claude Code trajectory to {trajectory_path}")
-        except OSError as exc:
-            self.logger.debug(
-                f"Failed to write trajectory file {trajectory_path}: {exc}"
-            )
-
-        if trajectory.final_metrics:
-            populate_context_from_final_metrics(context, trajectory.final_metrics)
+        self._write_trajectory(trajectory, context)
 
     def _build_register_skills_command(self) -> str | None:
         """Return a shell command that copies skills from the environment to Claude's config.
@@ -1332,6 +1359,7 @@ class ClaudeCode(BaseInstalledAgent):
 
         cli_flags = self.build_cli_flags()
         extra_flags = (cli_flags + " ") if cli_flags else ""
+        output_path = (EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME).as_posix()
 
         await self.exec_as_agent(
             environment,
@@ -1346,7 +1374,7 @@ class ClaudeCode(BaseInstalledAgent):
                 f"--permission-mode=bypassPermissions "
                 f"{extra_flags}"
                 f"--print -- {escaped_instruction} 2>&1 </dev/null | tee "
-                f"/logs/agent/claude-code.txt"
+                f"{output_path}"
             ),
             env=env,
         )

--- a/src/pier/agents/installed/grok_build.py
+++ b/src/pier/agents/installed/grok_build.py
@@ -1,0 +1,382 @@
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+from pier.agents.installed.base import CliFlag, with_prompt_template
+from pier.agents.network import allowlist_from_urls
+from pier.agents.installed.claude_code import ClaudeCode
+from pier.environments.base import BaseEnvironment
+from pier.models.agent.context import AgentContext
+from pier.models.agent.install import AgentInstallSpec, InstallStep
+from pier.models.agent.name import AgentName
+from pier.models.agent.network import NetworkAllowlist
+from pier.models.trial.paths import EnvironmentPaths
+
+_DEFAULT_AUTH_FILE = "~/.grok/auth.json"
+
+
+class GrokBuild(ClaudeCode):
+    """xAI's Grok Build CLI (https://github.com/xai-org/grok-build).
+
+    Runs ``grok -p`` headless with ``--output-format streaming-messages-json``,
+    which emits the same NDJSON wire format as Claude Code's stream-json mode
+    (system/init, assistant, user, result events with Anthropic-style message
+    bodies). We therefore subclass :class:`ClaudeCode` purely to reuse its
+    event-to-ATIF trajectory conversion; install, auth, and invocation are
+    Grok-specific.
+
+    Auth resolution order:
+      1. ``XAI_API_KEY`` env (API auth against api.x.ai)
+      2. a Grok CLI session ``auth.json`` (kwarg ``auth_file``, default
+         ``~/.grok/auth.json``) uploaded into an ephemeral in-container
+         ``GROK_HOME`` under /tmp, removed when the run finishes so the
+         credential never lands in the persisted logs mount.
+    """
+
+    SUPPORTS_ATIF: bool = True
+
+    _OUTPUT_FILENAME = "grok-build.txt"
+    _STDERR_FILENAME = "grok-build-stderr.txt"
+    # Outside /logs so the session credential is never persisted to the host.
+    _GROK_HOME = "/tmp/grok-build-home"
+
+    CLI_FLAGS = [
+        CliFlag(
+            "max_turns",
+            cli="--max-turns",
+            type="int",
+            env_fallback="GROK_BUILD_MAX_TURNS",
+        ),
+        CliFlag(
+            "reasoning_effort",
+            cli="--reasoning-effort",
+            type="enum",
+            choices=["low", "medium", "high", "xhigh"],
+            env_fallback="GROK_BUILD_EFFORT_LEVEL",
+        ),
+        CliFlag(
+            "disable_web_search",
+            cli="--disable-web-search",
+            type="bool",
+            default=True,
+        ),
+        CliFlag(
+            "no_plan",
+            cli="--no-plan",
+            type="bool",
+            default=True,
+        ),
+        CliFlag(
+            # Default on: pier's converter has no inline-subagent support, so
+            # subagent events would interleave into the mainline trajectory.
+            # Opt back in with no_subagents=False if step attribution does not
+            # matter for your analysis.
+            "no_subagents",
+            cli="--no-subagents",
+            type="bool",
+            default=True,
+        ),
+    ]
+    ENV_VARS = []
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        auth_file: str | None = None,
+        *args,
+        **kwargs,
+    ):
+        # Inherited ClaudeCode kwargs with no grok CLI equivalent would be
+        # silently dropped by BaseInstalledAgent's kwarg extraction; reject
+        # them eagerly instead.
+        claude_only_kwargs = (
+            {flag.kwarg for flag in ClaudeCode.CLI_FLAGS}
+            | {var.kwarg for var in ClaudeCode.ENV_VARS}
+        ) - {flag.kwarg for flag in self.CLI_FLAGS}
+        rejected = sorted(claude_only_kwargs & set(kwargs))
+        if rejected:
+            raise ValueError(
+                "kwargs not supported by the grok-build agent (Claude Code "
+                f"only): {', '.join(rejected)}"
+            )
+
+        self._auth_file = auth_file or _DEFAULT_AUTH_FILE
+        self._instruction_used: str | None = None
+        super().__init__(logs_dir, *args, **kwargs)
+
+        if self.memory_dir:
+            # memory_dir can only come from the agent config; fail fast.
+            raise ValueError("The grok-build agent does not support memory_dir yet.")
+        if self.mcp_servers or self.skills_dir:
+            # These may be injected from task.config.environment, which other
+            # agents run with; degrade to a warning instead of failing trials.
+            self.logger.warning(
+                "The grok-build agent does not support MCP servers or skills "
+                "yet; ignoring them for this run."
+            )
+        # Fail before the environment is built, not after the CLI install.
+        self._session_auth_path()
+
+    @staticmethod
+    def name() -> str:
+        return AgentName.GROK_BUILD.value
+
+    def get_version_command(self) -> str | None:
+        return 'export PATH="$HOME/.grok/bin:$PATH"; grok --version'
+
+    def install_spec(self) -> AgentInstallSpec:
+        root_run = (
+            "if command -v apt-get &> /dev/null; then"
+            "  apt-get update && apt-get install -y curl ca-certificates;"
+            " elif command -v apk &> /dev/null; then"
+            # coreutils provides stdbuf, which busybox lacks
+            "  apk add --no-cache curl bash ca-certificates coreutils;"
+            " elif command -v yum &> /dev/null; then"
+            "  yum install -y curl ca-certificates;"
+            " else"
+            '  echo "Warning: no known package manager, assuming curl exists" >&2;'
+            " fi"
+        )
+        version_arg = f" -s {shlex.quote(self._version)}" if self._version else ""
+        agent_run = (
+            "set -euo pipefail; "
+            f"curl -fsSL https://x.ai/cli/install.sh | bash{version_arg} && "
+            "echo 'export PATH=\"$HOME/.grok/bin:$PATH\"' >> ~/.bashrc && "
+            'export PATH="$HOME/.grok/bin:$PATH" && '
+            "grok --version"
+        )
+        return AgentInstallSpec(
+            agent_name=self.name(),
+            version=self._version,
+            steps=[
+                InstallStep(
+                    user="root",
+                    env={"DEBIAN_FRONTEND": "noninteractive"},
+                    run=root_run,
+                ),
+                InstallStep(user="agent", run=agent_run),
+            ],
+            verification_command=self.get_version_command(),
+        )
+
+    def network_allowlist(self) -> NetworkAllowlist:
+        default_domains = [
+            # installer script + release binaries
+            "x.ai",
+            "storage.googleapis.com",
+            # session-auth inference proxy + OIDC token refresh
+            "cli-chat-proxy.grok.com",
+            "auth.x.ai",
+        ]
+        if self._get_env("XAI_API_KEY"):
+            default_domains.append("api.x.ai")
+        override_urls = [
+            self._get_env(env_key)
+            for env_key in ("GROK_CLI_CHAT_PROXY_BASE_URL", "GROK_XAI_API_BASE_URL")
+        ]
+        return allowlist_from_urls(
+            [url for url in override_urls if url], default_domains=default_domains
+        )
+
+    def _session_auth_path(self) -> Path | None:
+        """Host path of the session auth.json, or None for API-key auth.
+
+        Raises ValueError when neither auth source is available.
+        """
+        auth_path = Path(self._auth_file).expanduser()
+        if self._get_env("XAI_API_KEY"):
+            if (
+                "XAI_API_KEY" not in self._extra_env
+                and os.environ.get("XAI_API_KEY")
+                and auth_path.is_file()
+            ):
+                # Available model ids can differ per credential/auth mode, so
+                # an ambient key silently overriding a session file is worth a
+                # visible note.
+                self.logger.warning(
+                    "Using XAI_API_KEY from the host environment; ignoring "
+                    f"the Grok session file at {auth_path}"
+                )
+            return None
+        if not auth_path.is_file():
+            raise ValueError(
+                f"Grok auth file not found at {auth_path} and XAI_API_KEY is not "
+                "set. Run `grok login` on the host or provide auth_file/XAI_API_KEY."
+            )
+        return auth_path
+
+    def _resolved_model(self) -> str | None:
+        """Model id for --model, stripping a pier-style provider prefix
+        (e.g. "xai/grok-4.6"). None defers to the CLI's own default."""
+        if not self.model_name:
+            return None
+        return self.model_name.split("/", 1)[-1]
+
+    @with_prompt_template
+    async def run(
+        self, instruction: str, environment: BaseEnvironment, context: AgentContext
+    ) -> None:
+        self._instruction_used = instruction
+        escaped_instruction = shlex.quote(instruction)
+        grok_home = self._GROK_HOME
+
+        # Resolve the auth mode BEFORE scrubbing empty values below — an
+        # explicit XAI_API_KEY="" override must keep forcing session auth.
+        auth_path = self._session_auth_path()
+
+        env: dict[str, str | None] = {
+            "GROK_HOME": grok_home,
+            "GROK_TELEMETRY_ENABLED": "0",
+            "GROK_FEEDBACK_ENABLED": "0",
+            "XAI_API_KEY": self._get_env("XAI_API_KEY"),
+            "GROK_CLI_CHAT_PROXY_BASE_URL": self._get_env(
+                "GROK_CLI_CHAT_PROXY_BASE_URL"
+            ),
+            "GROK_XAI_API_BASE_URL": self._get_env("GROK_XAI_API_BASE_URL"),
+        }
+        process_env = self.build_process_env(env)
+        # Drop empty credentials so the CLI does not select API-key auth on an
+        # empty XAI_API_KEY while pier prepared session auth. _exec re-merges
+        # self._extra_env over the env we pass, so the empty key must be kept
+        # out of there too — scoped to this run and restored afterwards, since
+        # _extra_env is shared agent state.
+        process_env = {key: value for key, value in process_env.items() if value}
+        original_extra_env = self._extra_env
+        if original_extra_env.get("XAI_API_KEY") == "":
+            self._extra_env = {
+                key: value
+                for key, value in original_extra_env.items()
+                if key != "XAI_API_KEY"
+            }
+
+        await self.exec_as_agent(
+            environment, command=f"mkdir -p {grok_home}", env=process_env
+        )
+
+        if auth_path:
+            # upload_file keeps the credential out of both the command line
+            # and the exec env (docker materializes exec env as host argv).
+            remote_auth_path = f"{grok_home}/auth.json"
+            await environment.upload_file(auth_path, remote_auth_path)
+            # upload_file copies as root; fix ownership for the agent user.
+            if environment.default_user is not None:
+                await self.exec_as_root(
+                    environment,
+                    command=(
+                        f"chown {environment.default_user} {remote_auth_path}"
+                        f" && chmod 600 {remote_auth_path}"
+                    ),
+                )
+
+        cli_flags = self.build_cli_flags()
+        extra_flags = (cli_flags + " ") if cli_flags else ""
+        output_path = (EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME).as_posix()
+        stderr_path = (EnvironmentPaths.agent_dir / self._STDERR_FILENAME).as_posix()
+
+        model = self._resolved_model()
+        model_flag = f"--model {shlex.quote(model)} " if model else ""
+
+        # No auto-update checks mid-trial; the installed version is
+        # authoritative. -p= keeps hyphen-leading instructions from parsing as
+        # CLI options; stderr stays out of the NDJSON stream the trajectory is
+        # parsed from.
+        grok_command = (
+            f"printf '[cli]\\nauto_update = false\\n' > {grok_home}/config.toml"
+            " && "
+            'export PATH="$HOME/.grok/bin:$PATH" && '
+            f"grok {model_flag}"
+            f"--output-format streaming-messages-json "
+            f"--permission-mode bypassPermissions "
+            f"{extra_flags}"
+            f"-p={escaped_instruction} </dev/null "
+            f"2>{stderr_path} | stdbuf -oL tee {output_path}"
+        )
+
+        try:
+            await self.exec_as_agent(environment, command=grok_command, env=process_env)
+        finally:
+            self._extra_env = original_extra_env
+            # GROK_HOME holds the session credential; never leave it behind.
+            # Best-effort with a short timeout — a wedged container must not
+            # hang the trial or mask the run's own error (the environment is
+            # torn down after the trial either way).
+            try:
+                await self.exec_as_agent(
+                    environment,
+                    command=f"rm -rf {grok_home} || true",
+                    timeout_sec=60,
+                )
+            except Exception:
+                self.logger.debug("grok-build credential cleanup failed")
+
+    def _load_stream_events(self) -> tuple[list[dict[str, Any]], str | None]:
+        """Parse the captured NDJSON stream into Claude-session-shaped events.
+
+        Collects assistant/user message events plus the session id; the final
+        result event's cost is read by the inherited
+        ``_parse_total_cost_from_stream_json`` (via ``_OUTPUT_FILENAME``).
+        """
+        events: list[dict[str, Any]] = []
+        session_id: str | None = None
+        for event in self._iter_stream_events():
+            if session_id is None and isinstance(event.get("session_id"), str):
+                session_id = event["session_id"]
+            if event.get("type") in ("assistant", "user") and isinstance(
+                event.get("message"), dict
+            ):
+                # NOTE: subagent events (parent_tool_use_id set; only emitted
+                # when no_subagents=False) are kept in stream order — do NOT
+                # map them onto isSidechain: the inherited converter hoists
+                # sidechain events ahead of the mainline, which reorders the
+                # trajectory when events carry no timestamps.
+                # The inherited converter sorts on string timestamps; drop
+                # any non-string form the CLI may emit.
+                if not isinstance(event.get("timestamp"), str):
+                    event.pop("timestamp", None)
+                events.append(event)
+        return events, session_id
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        events, session_id = self._load_stream_events()
+        if not events:
+            self.logger.debug("No grok-build stream events found")
+            return
+
+        # Prepend the instruction as the opening user step unless the CLI
+        # already echoed the prompt as a user event.
+        first_user_message = next(
+            (
+                event["message"]
+                for event in events
+                if event.get("type") == "user" and not event.get("isSidechain")
+            ),
+            None,
+        )
+        prompt_echoed = bool(
+            first_user_message
+            and first_user_message.get("content") == self._instruction_used
+        )
+        if self._instruction_used and not prompt_echoed:
+            events.insert(
+                0,
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": self._instruction_used},
+                },
+            )
+
+        try:
+            # The stream is wire-compatible with Claude Code session events, so
+            # the inherited converter consumes it directly.
+            trajectory = self._convert_raw_events_to_trajectory(
+                events, session_id or "grok-build"
+            )
+        except Exception:
+            self.logger.exception("Failed to convert grok-build stream")
+            return
+        if not trajectory:
+            self.logger.debug("Failed to convert grok-build stream to trajectory")
+            return
+
+        self._write_trajectory(trajectory, context)

--- a/src/pier/models/agent/name.py
+++ b/src/pier/models/agent/name.py
@@ -9,6 +9,7 @@ class AgentName(str, Enum):
     CODEX = "codex"
     CURSOR_CLI = "cursor-cli"
     GEMINI_CLI = "gemini-cli"
+    GROK_BUILD = "grok-build"
     MINI_SWE_AGENT = "mini-swe-agent"
     SWE_AGENT = "swe-agent"
     OPENCODE = "opencode"

--- a/tests/test_grok_build.py
+++ b/tests/test_grok_build.py
@@ -1,0 +1,356 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from pier.agents.installed.grok_build import GrokBuild
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_grok_env(monkeypatch):
+    """Auth mode and flag fallbacks read os.environ; keep the tests hermetic."""
+    for key in (
+        "XAI_API_KEY",
+        "GROK_CLI_CHAT_PROXY_BASE_URL",
+        "GROK_XAI_API_BASE_URL",
+        "GROK_BUILD_MAX_TURNS",
+        "GROK_BUILD_EFFORT_LEVEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_agent(tmp_path: Path, **kwargs) -> GrokBuild:
+    """Construct a GrokBuild with a stub session auth file (hermetic in CI)."""
+    auth_file = tmp_path / "grok-auth.json"
+    auth_file.write_text("{}")
+    kwargs.setdefault("auth_file", str(auth_file))
+    return GrokBuild(logs_dir=tmp_path, **kwargs)
+
+
+def _write_stream(logs_dir: Path, lines: list[dict]) -> None:
+    path = logs_dir / "grok-build.txt"
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+
+
+_INIT_EVENT = {
+    "type": "system",
+    "subtype": "init",
+    "session_id": "0199-test-session",
+    "model": "grok-4.6",
+    "cwd": "/app",
+}
+
+_TOOL_CALL_EVENT = {
+    "type": "assistant",
+    "session_id": "0199-test-session",
+    "message": {
+        "id": "msg_0",
+        "role": "assistant",
+        "model": "grok-4.6",
+        "content": [
+            {"type": "thinking", "thinking": "Create the file."},
+            {
+                "type": "tool_use",
+                "id": "call-1",
+                "name": "search_replace",
+                "input": {"path": "hello.txt", "content": "hi"},
+            },
+        ],
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 50,
+            "cache_creation_input_tokens": 0,
+        },
+        "stop_reason": "tool_use",
+    },
+}
+
+_TOOL_RESULT_EVENT = {
+    "type": "user",
+    "session_id": "0199-test-session",
+    "message": {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "call-1", "content": "ok"}],
+    },
+}
+
+_FINAL_EVENT = {
+    "type": "assistant",
+    "session_id": "0199-test-session",
+    "message": {
+        "id": "msg_1",
+        "role": "assistant",
+        "model": "grok-4.6",
+        "content": [{"type": "text", "text": "Done."}],
+        "usage": {"input_tokens": 120, "output_tokens": 5},
+        "stop_reason": "end_turn",
+    },
+}
+
+_RESULT_EVENT = {
+    "type": "result",
+    "subtype": "success",
+    "session_id": "0199-test-session",
+    "total_cost_usd": 0.5,
+    "num_turns": 2,
+}
+
+_FULL_STREAM = [
+    _INIT_EVENT,
+    _TOOL_CALL_EVENT,
+    _TOOL_RESULT_EVENT,
+    _FINAL_EVENT,
+    _RESULT_EVENT,
+]
+
+
+def test_install_spec_pins_version(tmp_path: Path):
+    agent = _make_agent(tmp_path, version="1.0.3")
+
+    spec = agent.install_spec()
+
+    assert "install.sh | bash -s 1.0.3" in spec.steps[-1].run
+    assert spec.version == "1.0.3"
+
+
+def test_install_spec_unpinned_omits_version_arg(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+
+    assert "install.sh | bash &&" in agent.install_spec().steps[-1].run
+
+
+def test_install_spec_alpine_includes_coreutils_for_stdbuf(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+
+    assert "coreutils" in agent.install_spec().steps[0].run
+
+
+def test_default_cli_flags(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+
+    flags = agent.build_cli_flags()
+
+    assert "--disable-web-search" in flags
+    assert "--no-plan" in flags
+    assert "--no-subagents" in flags
+    assert "--max-turns" not in flags
+
+
+def test_subagents_can_be_enabled(tmp_path: Path):
+    agent = _make_agent(tmp_path, no_subagents=False)
+
+    assert "--no-subagents" not in agent.build_cli_flags()
+
+
+def test_reasoning_effort_and_max_turns_flags(tmp_path: Path):
+    agent = _make_agent(tmp_path, reasoning_effort="xhigh", max_turns=50)
+
+    flags = agent.build_cli_flags()
+
+    assert "--reasoning-effort xhigh" in flags
+    assert "--max-turns 50" in flags
+
+
+def test_invalid_reasoning_effort_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="reasoning_effort"):
+        _make_agent(tmp_path, reasoning_effort="ultra")
+
+
+def test_claude_only_kwargs_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="max_budget_usd"):
+        _make_agent(tmp_path, max_budget_usd="5")
+
+
+def test_memory_dir_rejected_at_construction(tmp_path: Path):
+    with pytest.raises(ValueError, match="memory"):
+        _make_agent(tmp_path, memory_dir="/some/memory")
+
+
+def test_task_supplied_skills_warn_but_construct(tmp_path: Path):
+    # skills_dir/mcp_servers can be injected from task configs; they must not
+    # abort the trial at construction.
+    agent = _make_agent(tmp_path, skills_dir="/task/skills")
+
+    assert agent.skills_dir == "/task/skills"
+
+
+def test_missing_auth_raises_at_construction(tmp_path: Path):
+    with pytest.raises(ValueError, match="XAI_API_KEY"):
+        GrokBuild(logs_dir=tmp_path, auth_file=str(tmp_path / "missing-auth.json"))
+
+
+def test_api_key_mode_needs_no_auth_file(tmp_path: Path):
+    agent = GrokBuild(
+        logs_dir=tmp_path,
+        auth_file=str(tmp_path / "missing-auth.json"),
+        extra_env={"XAI_API_KEY": "xai-test"},
+    )
+
+    assert agent._session_auth_path() is None
+
+
+def test_resolved_model_strips_provider_prefix(tmp_path: Path):
+    assert (
+        _make_agent(tmp_path, model_name="xai/grok-4.6")._resolved_model() == "grok-4.6"
+    )
+    assert _make_agent(tmp_path, model_name="grok-4.5")._resolved_model() == "grok-4.5"
+    assert _make_agent(tmp_path)._resolved_model() is None
+
+
+def test_network_allowlist_session_mode(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+
+    domains = agent.network_allowlist().domains
+
+    assert "cli-chat-proxy.grok.com" in domains
+    assert "auth.x.ai" in domains
+    assert "x.ai" in domains
+    assert "storage.googleapis.com" in domains
+    assert "api.x.ai" not in domains
+
+
+def test_network_allowlist_api_key_mode(tmp_path: Path):
+    agent = _make_agent(tmp_path, extra_env={"XAI_API_KEY": "xai-test"})
+
+    assert "api.x.ai" in agent.network_allowlist().domains
+
+
+def test_network_allowlist_skips_placeholder_urls(tmp_path: Path):
+    agent = _make_agent(
+        tmp_path, extra_env={"GROK_CLI_CHAT_PROXY_BASE_URL": "${PROXY_URL}"}
+    )
+
+    domains = agent.network_allowlist().domains
+
+    assert "${PROXY_URL}" not in domains
+    assert "cli-chat-proxy.grok.com" in domains
+
+
+def test_stream_converts_to_atif_trajectory(tmp_path: Path):
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    _write_stream(tmp_path, _FULL_STREAM)
+
+    events, session_id = agent._load_stream_events()
+    assert session_id == "0199-test-session"
+    # init and result events are not message events
+    assert len(events) == 3
+    # the inherited parser reads the result event from the stream file
+    assert agent._parse_total_cost_from_stream_json() == 0.5
+
+    events.insert(
+        0, {"type": "user", "message": {"role": "user", "content": "Create hello.txt"}}
+    )
+    trajectory = agent._convert_raw_events_to_trajectory(events, session_id)
+
+    assert trajectory is not None
+    assert trajectory.steps[0].source == "user"
+    assert trajectory.steps[0].message == "Create hello.txt"
+
+    tool_steps = [s for s in trajectory.steps if s.tool_calls]
+    assert tool_steps and tool_steps[0].tool_calls[0].function_name == "search_replace"
+    assert tool_steps[0].observation.results[0].content == "ok"
+
+    agent_steps = [s for s in trajectory.steps if s.source == "agent"]
+    assert all(s.model_name == "grok-4.6" for s in agent_steps)
+
+    final = trajectory.final_metrics
+    assert final is not None
+    assert final.total_completion_tokens == 25
+    assert final.total_cost_usd == 0.5
+
+
+def test_cost_uses_first_result_event(tmp_path: Path):
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    trailing_error_result = {
+        "type": "result",
+        "subtype": "error_during_execution",
+        "total_cost_usd": 0.0,
+    }
+    _write_stream(tmp_path, [*_FULL_STREAM, trailing_error_result])
+
+    assert agent._parse_total_cost_from_stream_json() == 0.5
+
+
+def test_non_string_timestamps_are_dropped(tmp_path: Path):
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    numeric_ts_event = dict(_FINAL_EVENT, timestamp=1755100000000)
+    _write_stream(tmp_path, [_INIT_EVENT, numeric_ts_event, _RESULT_EVENT])
+
+    events, session_id = agent._load_stream_events()
+
+    assert "timestamp" not in events[0]
+    # the converter's string sort must not raise on the sanitized events
+    assert agent._convert_raw_events_to_trajectory(events, session_id) is not None
+
+
+def test_subagent_events_keep_stream_order(tmp_path: Path):
+    # Subagent events must not be tagged isSidechain: the inherited converter
+    # hoists sidechains ahead of the mainline, which would reorder the
+    # timestamp-less grok stream.
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    subagent_event = dict(_FINAL_EVENT, parent_tool_use_id="call-parent-1")
+    _write_stream(tmp_path, [_INIT_EVENT, _TOOL_CALL_EVENT, subagent_event])
+
+    events, session_id = agent._load_stream_events()
+
+    assert all(event.get("isSidechain") is None for event in events)
+    trajectory = agent._convert_raw_events_to_trajectory(list(events), session_id)
+    assert trajectory.steps[0].tool_calls, "mainline tool call must stay first"
+
+
+def test_prompt_echo_is_not_duplicated(tmp_path: Path):
+    from pier.models.agent.context import AgentContext
+
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    echo_event = {
+        "type": "user",
+        "session_id": "0199-test-session",
+        "message": {"role": "user", "content": "Create hello.txt"},
+    }
+    _write_stream(tmp_path, [_INIT_EVENT, echo_event, _FINAL_EVENT, _RESULT_EVENT])
+    agent._instruction_used = "Create hello.txt"
+
+    agent.populate_context_post_run(AgentContext())
+
+    written = json.loads((tmp_path / "trajectory.json").read_text())
+    user_steps = [
+        s
+        for s in written["steps"]
+        if s["source"] == "user" and s.get("message") == "Create hello.txt"
+    ]
+    assert len(user_steps) == 1
+
+
+def test_malformed_stream_lines_are_skipped(tmp_path: Path):
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    path = tmp_path / "grok-build.txt"
+    path.write_text(
+        json.dumps(_INIT_EVENT)
+        + "\nnot json\n{truncated\n"
+        + json.dumps(_FINAL_EVENT)
+        + "\n"
+        + json.dumps(_RESULT_EVENT)
+        + "\n"
+    )
+
+    events, session_id = agent._load_stream_events()
+
+    assert session_id == "0199-test-session"
+    assert len(events) == 1
+
+
+def test_populate_context_writes_trajectory(tmp_path: Path):
+    from pier.models.agent.context import AgentContext
+
+    agent = _make_agent(tmp_path, model_name="grok-4.6")
+    _write_stream(tmp_path, _FULL_STREAM)
+    agent._instruction_used = "Create hello.txt"
+
+    context = AgentContext()
+    agent.populate_context_post_run(context)
+
+    written = json.loads((tmp_path / "trajectory.json").read_text())
+    assert written["agent"]["name"] == "grok-build"
+    assert written["session_id"] == "0199-test-session"
+    assert context.n_output_tokens == 25


### PR DESCRIPTION
Adds grok-build as an installed agent. 

Grok Build headless streaming-messages-json output is wire-compatible with Claude Code's stream-json, so GrokBuild subclasses ClaudeCode and reuses its ATIF converter; a small refactor splits the converter from session-file loading (_convert_raw_events_to_trajectory), parameterises the stream filename (_OUTPUT_FILENAME), and hardens stream reading (OSError/decode containment), behavior-neutral for claude-code.

Auth: XAI_API_KEY, or a Grok CLI session file uploaded via environment.upload_file into an ephemeral /tmp GROK_HOME (never in argv, exec env, or the logs mount; removed in finally). Network allowlist covers installer + session endpoints. Version pinning via agent.version. Kwargs: reasoning_effort, max_turns, disable_web_search/no_plan/no_subagents (all default on), claude-only kwargs are rejected eagerly.

Validated on DeepSWE tasks: 20-trial grok-4.5/4.6 sweep, oracle 10/10 / nop 0/10 controls, and an official-config (xhigh) run consistent with the public leaderboard. 25 unit tests included.
