### PR TITLE
Make verifier timeout attempts configurable and expose timeout subphases

### DIFF
--- a/src/pier/cli/jobs.py
+++ b/src/pier/cli/jobs.py
@@ -224,6 +224,17 @@ def start(
             show_default=False,
         ),
     ] = None,
+    verifier_max_attempts: Annotated[
+        int | None,
+        Option(
+            "--verifier-max-attempts",
+            "--verifier-attempts",
+            help="Maximum number of verifier execution attempts (default: 2). Set to 1 to disable retries.",
+            rich_help_panel="Job Settings",
+            show_default=False,
+        ),
+    ] = None,
+
     agent_setup_timeout_multiplier: Annotated[
         float | None,
         Option(
@@ -695,8 +706,11 @@ def start(
 
     if verifier_env is not None:
         config.verifier.env.update(parse_env_vars(verifier_env))
+    if verifier_max_attempts is not None:
+        config.verifier.max_attempts = verifier_max_attempts
     if disable_verification:
         config.verifier.disable = disable_verification
+
 
     if artifact_paths is not None:
         config.artifacts = list(artifact_paths)

--- a/src/pier/job.py
+++ b/src/pier/job.py
@@ -756,10 +756,18 @@ class Job:
 
             async def on_verification_start(event: TrialHookEvent):
                 if event.trial_id in trial_progress_tasks:
+                    attempt_str = ""
+                    if event.result is not None and event.result.verifier_attempt is not None:
+                        max_att = (
+                            event.result.max_verifier_attempts
+                            or getattr(event.config.verifier, "max_attempts", 2)
+                        )
+                        attempt_str = f" (attempt {event.result.verifier_attempt}/{max_att})"
                     running_progress.update(
                         trial_progress_tasks[event.trial_id],
-                        description=f"{event.trial_id}: running verifier...",
+                        description=f"{event.trial_id}: running verifier{attempt_str}...",
                     )
+
 
             async def on_cancel(event: TrialHookEvent):
                 if event.trial_id in trial_progress_tasks:

--- a/src/pier/models/job/config.py
+++ b/src/pier/models/job/config.py
@@ -193,6 +193,8 @@ class RetryConfig(BaseModel):
         default_factory=lambda: {
             "AgentTimeoutError",
             "VerifierTimeoutError",
+            "VerifierTestExecutionTimeoutError",
+            "VerifierRewardParseTimeoutError",
             "RewardFileNotFoundError",
             "RewardFileEmptyError",
             "VerifierOutputParseError",

--- a/src/pier/models/task/config.py
+++ b/src/pier/models/task/config.py
@@ -181,8 +181,21 @@ class VerifierCollectConfig(BaseModel):
 
 
 class VerifierConfig(NetworkPolicyFieldsMixin):
-    timeout_sec: float = 600.0
+    timeout_sec: float = Field(
+        default=600.0,
+        description=(
+            "Total verifier timeout in seconds. Note that verifier.timeout_sec "
+            "currently wraps environment startup and test execution together, "
+            "rather than adding to verifier.environment.build_timeout_sec."
+        ),
+    )
+    max_attempts: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of verifier execution attempts (default: 2 in TrialConfig). Set to 1 to disable retries.",
+    )
     env: dict[str, str] = Field(default_factory=dict)
+
     user: str | int | None = Field(
         default=None,
         description="Username or UID to run the verifier as. None uses the environment's default USER (e.g., root).",

--- a/src/pier/models/trial/config.py
+++ b/src/pier/models/trial/config.py
@@ -173,13 +173,28 @@ class EnvironmentConfig(BaseModel):
 class VerifierConfig(BaseModel):
     override_timeout_sec: float | None = None
     max_timeout_sec: float | None = None
+    max_attempts: int = Field(
+        default=2,
+        ge=1,
+        description="Maximum number of verifier execution attempts. Set to 1 to disable retries.",
+    )
     env: dict[str, str] = Field(default_factory=dict)
     disable: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _handle_max_retries(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            if "max_retries" in data and "max_attempts" not in data:
+                data = dict(data)
+                data["max_attempts"] = data.pop("max_retries") + 1
+        return data
 
     @field_serializer("env")
     @classmethod
     def _serialize_env(cls, env: dict[str, str]) -> dict[str, str]:
         return templatize_sensitive_env(env)
+
 
 
 class TaskConfig(BaseModel):

--- a/src/pier/models/trial/paths.py
+++ b/src/pier/models/trial/paths.py
@@ -216,6 +216,12 @@ class TrialPaths:
         return self.trial_dir / "result.json"
 
     @property
+    def progress_path(self) -> Path:
+        """Durable progress state of the trial."""
+        return self.trial_dir / "progress.json"
+
+
+    @property
     def exception_message_path(self) -> Path:
         """
         A text file containing the exception message.

--- a/src/pier/models/trial/result.py
+++ b/src/pier/models/trial/result.py
@@ -15,6 +15,8 @@ class TimingInfo(BaseModel):
 
     started_at: datetime | None = None
     finished_at: datetime | None = None
+    attempt: int | None = None
+    max_attempts: int | None = None
 
 
 class ExceptionInfo(BaseModel):
@@ -64,6 +66,8 @@ class StepResult(BaseModel):
     exception_info: ExceptionInfo | None = None
     agent_execution: TimingInfo | None = None
     verifier: TimingInfo | None = None
+    verifier_attempt: int | None = None
+    max_verifier_attempts: int | None = None
 
 
 class TrialResult(BaseModel):
@@ -85,6 +89,8 @@ class TrialResult(BaseModel):
     agent_setup: TimingInfo | None = None
     agent_execution: TimingInfo | None = None
     verifier: TimingInfo | None = None
+    verifier_attempt: int | None = None
+    max_verifier_attempts: int | None = None
     n_agent_steps: int | None = None
     step_results: list[StepResult] | None = None
 

--- a/src/pier/trial/trial.py
+++ b/src/pier/trial/trial.py
@@ -8,7 +8,8 @@ import traceback
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
+
 
 from tenacity import (
     retry,
@@ -57,12 +58,20 @@ from pier.trial.execution import (
     EnvironmentStartTimeoutError,
     TrialExecution,
 )
+import time
 from pier.utils.logger import logger
-from pier.verifier.verifier import Verifier
-
-
-class VerifierTimeoutError(asyncio.TimeoutError):
-    pass
+from pier.verifier.verifier import (
+    Verifier,
+    VerifierArtifactTransferTimeoutError,
+    VerifierEnvironmentStartTimeoutError,
+    VerifierEnvironmentTimeoutError,
+    VerifierInfrastructureTimeoutError,
+    VerifierRewardDownloadTimeoutError,
+    VerifierRewardParseTimeoutError,
+    VerifierRewardTimeoutError,
+    VerifierTestExecutionTimeoutError,
+    VerifierTimeoutError,
+)
 
 
 __all__ = [
@@ -71,7 +80,16 @@ __all__ = [
     "EnvironmentStartTimeoutError",
     "Trial",
     "VerifierTimeoutError",
+    "VerifierEnvironmentTimeoutError",
+    "VerifierEnvironmentStartTimeoutError",
+    "VerifierArtifactTransferTimeoutError",
+    "VerifierInfrastructureTimeoutError",
+    "VerifierTestExecutionTimeoutError",
+    "VerifierRewardParseTimeoutError",
+    "VerifierRewardTimeoutError",
+    "VerifierRewardDownloadTimeoutError",
 ]
+
 
 
 TrialHookCallback = Callable[[TrialHookEvent], Awaitable[None]]
@@ -201,22 +219,27 @@ class Trial:
         self._log_handler: logging.Handler | None = None
         self._init_logger()
 
-        self._execution = TrialExecution.create(
-            task=self._task,
-            agent_config=config.agent,
-            environment_config=config.environment,
-            trial_paths=self._trial_paths,
-            session_id=self.config.trial_name,
-            logger=self._logger,
-            timeout_multiplier=config.timeout_multiplier,
-            agent_timeout_multiplier=config.agent_timeout_multiplier,
-            agent_setup_timeout_multiplier=config.agent_setup_timeout_multiplier,
-            environment_build_timeout_multiplier=config.environment_build_timeout_multiplier,
-            default_agent_setup_timeout_sec=self._AGENT_SETUP_TIMEOUT_SEC,
-        )
-        self._agent = self._execution.agent
-        self._environment = self._execution.environment
-        self._init_artifact_handler()
+        try:
+            self._execution = TrialExecution.create(
+                task=self._task,
+                agent_config=config.agent,
+                environment_config=config.environment,
+                trial_paths=self._trial_paths,
+                session_id=self.config.trial_name,
+                logger=self._logger,
+                timeout_multiplier=config.timeout_multiplier,
+                agent_timeout_multiplier=config.agent_timeout_multiplier,
+                agent_setup_timeout_multiplier=config.agent_setup_timeout_multiplier,
+                environment_build_timeout_multiplier=config.environment_build_timeout_multiplier,
+                default_agent_setup_timeout_sec=self._AGENT_SETUP_TIMEOUT_SEC,
+            )
+            self._agent = self._execution.agent
+            self._environment = self._execution.environment
+            self._init_artifact_handler()
+        except Exception:
+            self._close_logger_handler()
+            raise
+
 
         self._verifier_timeout_sec = min(
             config.verifier.override_timeout_sec
@@ -228,13 +251,45 @@ class Trial:
             else config.timeout_multiplier
         )
 
+        self._verifier_max_attempts = (
+            config.verifier.max_attempts
+            if config.verifier.max_attempts is not None
+            else getattr(self._task.config.verifier, "max_attempts", None) or 2
+        )
+
         self._result: TrialResult | None = None
+
+    def _write_progress(
+        self,
+        phase: str,
+        *,
+        verifier_attempt: int | None = None,
+        max_verifier_attempts: int | None = None,
+        **extra: Any,
+    ) -> None:
+        """Atomically persist durable progress state to trial_dir/progress.json."""
+        data = {
+            "trial_name": self.config.trial_name,
+            "task_name": self._task.name,
+            "phase": phase,
+            "verifier_attempt": verifier_attempt,
+            "max_verifier_attempts": max_verifier_attempts,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            **extra,
+        }
+        try:
+            self._trial_paths.progress_path.write_text(
+                json.dumps(data, indent=4)
+            )
+        except Exception as e:
+            self._logger.debug(f"Failed to write progress.json: {e}")
 
     @property
     def result(self) -> TrialResult:
         if self._result is None:
             raise RuntimeError("Trial result accessed before initialization")
         return self._result
+
 
     def _init_logger(self):
         self._logger = logger.getChild(f"{__name__}.{self.config.trial_name}")
@@ -284,6 +339,7 @@ class Trial:
         return self.config.trials_dir / self.config.trial_name
 
     async def _setup_environment(self) -> None:
+        self._write_progress("environment_setup")
         await self._invoke_hooks(TrialEvent.ENVIRONMENT_START)
 
         self.result.environment_setup = TimingInfo(
@@ -298,6 +354,7 @@ class Trial:
             self.result.environment_setup.finished_at = datetime.now(timezone.utc)
 
     async def _setup_agent(self) -> None:
+        self._write_progress("agent_setup")
         self.result.agent_setup = TimingInfo(started_at=datetime.now(timezone.utc))
         try:
             await self._execution.setup_agent()
@@ -305,6 +362,7 @@ class Trial:
             self.result.agent_setup.finished_at = datetime.now(timezone.utc)
 
     async def _execute_agent(self) -> None:
+        self._write_progress("agent_execution")
         await self._invoke_hooks(TrialEvent.AGENT_START)
 
         self.result.agent_execution = TimingInfo(started_at=datetime.now(timezone.utc))
@@ -319,34 +377,77 @@ class Trial:
         finally:
             self.result.agent_execution.finished_at = datetime.now(timezone.utc)
 
-    async def _run_verification(self) -> None:
-        await self._invoke_hooks(TrialEvent.VERIFICATION_START)
 
-        self.result.verifier = TimingInfo(started_at=datetime.now(timezone.utc))
+    async def _run_verification(self) -> None:
+        self.result.verifier = TimingInfo(
+            started_at=datetime.now(timezone.utc),
+            attempt=1,
+            max_attempts=self._verifier_max_attempts,
+        )
 
         try:
             await self._verify_with_retry()
         finally:
             self.result.verifier.finished_at = datetime.now(timezone.utc)
 
-    @retry(
-        reraise=True,
-        stop=stop_after_attempt(2),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type(VerifierTimeoutError),
-    )
     async def _verify_with_retry(self) -> None:
-        try:
-            self.result.verifier_result = await asyncio.wait_for(
-                self._verify_once(step_cfg=None),
-                timeout=self._verifier_timeout_sec,
+        max_attempts = self._verifier_max_attempts
+
+        for attempt in range(1, max_attempts + 1):
+            self.result.verifier_attempt = attempt
+            self.result.max_verifier_attempts = max_attempts
+            if self.result.verifier is not None:
+                self.result.verifier.attempt = attempt
+                self.result.verifier.max_attempts = max_attempts
+            self._write_progress(
+                "verifier",
+                verifier_attempt=attempt,
+                max_verifier_attempts=max_attempts,
             )
-        except asyncio.TimeoutError as e:
-            raise VerifierTimeoutError(
-                f"Verifier execution timed out after {
-                    self._verifier_timeout_sec
-                } seconds"
-            ) from e
+            await self._invoke_hooks(TrialEvent.VERIFICATION_START)
+
+            deadline = time.monotonic() + self._verifier_timeout_sec
+            try:
+                self.result.verifier_result = await self._verify_once(
+                    step_cfg=None,
+                    timeout_sec=self._verifier_timeout_sec,
+                    deadline=deadline,
+                )
+                return
+            except VerifierTestExecutionTimeoutError as exc:
+                # Do not retry candidate test-execution timeout by default
+                self._logger.warning(
+                    f"Verifier attempt {attempt}/{max_attempts} failed with candidate "
+                    f"test execution timeout: {exc}. Not retrying candidate test timeout."
+                )
+                raise
+            except (
+                VerifierEnvironmentTimeoutError,
+                VerifierArtifactTransferTimeoutError,
+                EnvironmentStartTimeoutError,
+            ) as exc:
+                self._logger.warning(
+                    f"Verifier attempt {attempt}/{max_attempts} failed with infrastructure "
+                    f"timeout: {exc}"
+                )
+                if attempt < max_attempts:
+                    backoff = min(10.0, 1.0 * (2 ** (attempt - 1)))
+                    self._logger.info(
+                        f"Retrying verifier infrastructure failure in {backoff:.1f}s "
+                        f"(attempt {attempt + 1}/{max_attempts})..."
+                    )
+                    await asyncio.sleep(backoff)
+                else:
+                    raise
+            except VerifierTimeoutError as exc:
+                self._logger.warning(
+                    f"Verifier attempt {attempt}/{max_attempts} failed with timeout: {exc}"
+                )
+                if attempt < max_attempts and not isinstance(exc, VerifierTestExecutionTimeoutError):
+                    backoff = min(10.0, 1.0 * (2 ** (attempt - 1)))
+                    await asyncio.sleep(backoff)
+                else:
+                    raise
 
     async def _verify_once(
         self,
@@ -354,6 +455,8 @@ class Trial:
         step_cfg: StepConfig | None,
         verifier_env: dict[str, str] | None = None,
         artifacts_dir: Path | None = None,
+        timeout_sec: float | None = None,
+        deadline: float | None = None,
     ) -> VerifierResult:
         separate_env_config = resolve_effective_verifier_env_config(
             self._task.config,
@@ -369,7 +472,7 @@ class Trial:
                 verifier_env=verifier_env,
                 step_name=step_cfg.name if step_cfg is not None else None,
             )
-            return await verifier.verify()
+            return await verifier.verify(timeout_sec=timeout_sec, deadline=deadline)
 
         return await self._verify_with_separate_environment(
             separate_env_config,
@@ -382,6 +485,8 @@ class Trial:
                 else self._trial_paths.artifacts_dir
             ),
             artifacts=step_cfg.artifacts if step_cfg is not None else None,
+            timeout_sec=timeout_sec,
+            deadline=deadline,
         )
 
     async def _verify_with_separate_environment(
@@ -393,7 +498,18 @@ class Trial:
         verifier_env: dict[str, str] | None,
         artifacts_dir: Path,
         artifacts: Sequence[str | ArtifactConfig] | None = None,
+        timeout_sec: float | None = None,
+        deadline: float | None = None,
     ) -> VerifierResult:
+        if deadline is None and timeout_sec is not None:
+            deadline = time.monotonic() + timeout_sec
+
+        def _remaining_sec() -> float | None:
+            if deadline is None:
+                return timeout_sec
+            rem = deadline - time.monotonic()
+            return max(0.0, rem)
+
         env = EnvironmentFactory.create_environment_from_config(
             config=self.config.environment,
             environment_dir=self._verifier_env_build_context(step_cfg),
@@ -412,18 +528,47 @@ class Trial:
             ),
         )
         try:
-            await env.start(force_build=False)
+            rem = _remaining_sec()
+            if rem is not None and rem <= 0:
+                raise VerifierEnvironmentTimeoutError(
+                    f"Verifier environment startup timed out (verifier timeout of {timeout_sec}s exhausted)"
+                )
+            try:
+                start_coro = env.start(force_build=False)
+                if rem is not None:
+                    await asyncio.wait_for(start_coro, timeout=rem)
+                else:
+                    await start_coro
+            except asyncio.TimeoutError as exc:
+                raise VerifierEnvironmentTimeoutError(
+                    f"Verifier environment startup timed out after {timeout_sec} seconds"
+                ) from exc
+
             env_paths = env.env_paths
 
-            await env.empty_dirs([env_paths.verifier_dir], chmod=True)
-
-            await self._artifact_handler.upload_artifacts(
-                env,
-                artifacts_dir=artifacts_dir,
-                source_artifacts_dir=self._environment.env_paths.artifacts_dir,
-                target_artifacts_dir=env_paths.artifacts_dir,
-                artifacts=artifacts,
-            )
+            rem = _remaining_sec()
+            if rem is not None and rem <= 0:
+                raise VerifierArtifactTransferTimeoutError(
+                    f"Verifier artifact transfer timed out (verifier timeout of {timeout_sec}s exhausted)"
+                )
+            try:
+                async def _prep_env():
+                    await env.empty_dirs([env_paths.verifier_dir], chmod=True)
+                    await self._artifact_handler.upload_artifacts(
+                        env,
+                        artifacts_dir=artifacts_dir,
+                        source_artifacts_dir=self._environment.env_paths.artifacts_dir,
+                        target_artifacts_dir=env_paths.artifacts_dir,
+                        artifacts=artifacts,
+                    )
+                if rem is not None:
+                    await asyncio.wait_for(_prep_env(), timeout=rem)
+                else:
+                    await _prep_env()
+            except asyncio.TimeoutError as exc:
+                raise VerifierArtifactTransferTimeoutError(
+                    f"Verifier artifact transfer timed out after {timeout_sec} seconds"
+                ) from exc
 
             verifier = Verifier(
                 task=self._task,
@@ -435,12 +580,13 @@ class Trial:
                 verifier_env=verifier_env,
                 step_name=step_cfg.name if step_cfg is not None else None,
             )
-            return await verifier.verify()
+            return await verifier.verify(timeout_sec=timeout_sec, deadline=deadline)
         finally:
             try:
                 await asyncio.shield(env.stop(delete=self.config.environment.delete))
             except Exception as exc:
                 self._logger.debug(f"Failed to stop verifier env '{key}': {exc}")
+
 
     def _verifier_env_mounts(
         self,
@@ -515,8 +661,14 @@ class Trial:
         self.result.n_agent_steps = self.result.agent_step_count()
 
         self._trial_paths.result_path.write_text(self.result.model_dump_json(indent=4))
+        self._write_progress(
+            "completed",
+            verifier_attempt=self.result.verifier_attempt,
+            max_verifier_attempts=self.result.max_verifier_attempts,
+        )
 
         await self._invoke_hooks(TrialEvent.END)
+
 
     async def _maybe_download_logs(self, source_dir: str, target_dir: Path) -> None:
         if self._are_agent_logs_downloaded:
@@ -666,7 +818,13 @@ class Trial:
             specific_multiplier=self.config.verifier_timeout_multiplier,
         )
 
-        step_result.verifier = TimingInfo(started_at=datetime.now(timezone.utc))
+        step_result.verifier = TimingInfo(
+            started_at=datetime.now(timezone.utc),
+            attempt=1,
+            max_attempts=1,
+        )
+        step_result.verifier_attempt = 1
+        step_result.max_verifier_attempts = 1
         try:
             await self._invoke_hooks(TrialEvent.VERIFICATION_START)
             # Separate-mode verification runs in its own environment; the agent
@@ -679,13 +837,13 @@ class Trial:
                     chmod_dirs=[env_paths.verifier_dir],
                 )
 
-            step_result.verifier_result = await asyncio.wait_for(
-                self._verify_once(
-                    step_cfg=step_cfg,
-                    verifier_env=step_cfg.verifier.env or None,
-                    artifacts_dir=artifacts_dir,
-                ),
-                timeout=timeout,
+            deadline = time.monotonic() + timeout if timeout is not None else None
+            step_result.verifier_result = await self._verify_once(
+                step_cfg=step_cfg,
+                verifier_env=step_cfg.verifier.env or None,
+                artifacts_dir=artifacts_dir,
+                timeout_sec=timeout,
+                deadline=deadline,
             )
         except Exception as e:
             if step_result.exception_info is None:
@@ -942,116 +1100,119 @@ class Trial:
         return artifacts_dir
 
     async def run(self) -> TrialResult:
-        self._trial_paths.trial_dir.mkdir(parents=True, exist_ok=True)
-        self._trial_paths.config_path.write_text(self.config.model_dump_json(indent=4))
-
-        self._result = TrialResult(
-            trial_name=self.config.trial_name,
-            task_name=self._task.name,
-            task_id=self.config.task.get_task_id(),
-            started_at=datetime.now(timezone.utc),
-            config=self.config,
-            task_checksum=self._task.checksum,
-            trial_uri=self._trial_paths.trial_dir.expanduser().resolve().as_uri(),
-            agent_info=self._agent.to_agent_info(),
-            source=self.config.task.source,
-        )
-
-        await self._invoke_hooks(TrialEvent.START)
-
         try:
-            await self._setup_environment()
-            await self._environment.run_healthcheck()
-            self._environment.default_user = self._task.config.agent.user
-            await self._setup_agent()
-            self._result.agent_info = self._agent.to_agent_info()
+            self._trial_paths.trial_dir.mkdir(parents=True, exist_ok=True)
+            self._trial_paths.config_path.write_text(self.config.model_dump_json(indent=4))
+
+            self._result = TrialResult(
+                trial_name=self.config.trial_name,
+                task_name=self._task.name,
+                task_id=self.config.task.get_task_id(),
+                started_at=datetime.now(timezone.utc),
+                config=self.config,
+                task_checksum=self._task.checksum,
+                trial_uri=self._trial_paths.trial_dir.expanduser().resolve().as_uri(),
+                agent_info=self._agent.to_agent_info(),
+                source=self.config.task.source,
+            )
+
+            await self._invoke_hooks(TrialEvent.START)
+
             try:
-                if self._task.has_steps:
-                    await self._run_steps()
-                else:
-                    try:
-                        await self._execute_agent()
-
-                        await self._maybe_download_logs(
-                            source_dir=self._environment.env_paths.agent_dir.as_posix(),
-                            target_dir=self._trial_paths.agent_dir,
-                        )
-                        self._maybe_populate_agent_context(self.result.agent_result)
-
-                    except (AgentTimeoutError, NonZeroAgentExitCodeError) as e:
-                        self.result.exception_info = ExceptionInfo.from_exception(e)
-                        self._trial_paths.exception_message_path.write_text(
-                            traceback.format_exc()
-                        )
-                        await self._maybe_download_logs(
-                            source_dir=self._environment.env_paths.agent_dir.as_posix(),
-                            target_dir=self._trial_paths.agent_dir,
-                        )
-                        self._maybe_populate_agent_context(self.result.agent_result)
-            finally:
-                self._environment.default_user = None
-
-            # Collect artifacts from the agent environment before verification
-            # so a separate verifier environment can receive them. Multi-step
-            # trials collect artifacts per-step inside _run_steps.
-            if not self._task.has_steps:
-                await self._run_pre_artifacts_script()
-                await self._run_collect_hooks()
-                await self._maybe_upload_agent_logs()
-                await self._collect_artifacts()
-
-                if (
-                    resolve_task_verifier_mode(self._task.config)
-                    == VerifierEnvironmentMode.SEPARATE
-                ):
-                    await self._stop_agent_environment(keep_images=True)
-
-            if not self.config.verifier.disable and not self._task.has_steps:
-                self._environment.default_user = self._task.config.verifier.user
+                await self._setup_environment()
+                await self._environment.run_healthcheck()
+                self._environment.default_user = self._task.config.agent.user
+                await self._setup_agent()
+                self._result.agent_info = self._agent.to_agent_info()
                 try:
-                    await self._run_verification()
+                    if self._task.has_steps:
+                        await self._run_steps()
+                    else:
+                        try:
+                            await self._execute_agent()
+
+                            await self._maybe_download_logs(
+                                source_dir=self._environment.env_paths.agent_dir.as_posix(),
+                                target_dir=self._trial_paths.agent_dir,
+                            )
+                            self._maybe_populate_agent_context(self.result.agent_result)
+
+                        except (AgentTimeoutError, NonZeroAgentExitCodeError) as e:
+                            self.result.exception_info = ExceptionInfo.from_exception(e)
+                            self._trial_paths.exception_message_path.write_text(
+                                traceback.format_exc()
+                            )
+                            await self._maybe_download_logs(
+                                source_dir=self._environment.env_paths.agent_dir.as_posix(),
+                                target_dir=self._trial_paths.agent_dir,
+                            )
+                            self._maybe_populate_agent_context(self.result.agent_result)
                 finally:
                     self._environment.default_user = None
 
-        except asyncio.CancelledError as e:
-            self._logger.debug(f"Trial {self.config.trial_name} cancelled")
-            if self.result.exception_info is None:
-                self.result.exception_info = ExceptionInfo.from_exception(e)
-                self._trial_paths.exception_message_path.write_text(
-                    traceback.format_exc()
+                # Collect artifacts from the agent environment before verification
+                # so a separate verifier environment can receive them. Multi-step
+                # trials collect artifacts per-step inside _run_steps.
+                if not self._task.has_steps:
+                    await self._run_pre_artifacts_script()
+                    await self._run_collect_hooks()
+                    await self._maybe_upload_agent_logs()
+                    await self._collect_artifacts()
+
+                    if (
+                        resolve_task_verifier_mode(self._task.config)
+                        == VerifierEnvironmentMode.SEPARATE
+                    ):
+                        await self._stop_agent_environment(keep_images=True)
+
+                if not self.config.verifier.disable and not self._task.has_steps:
+                    self._environment.default_user = self._task.config.verifier.user
+                    try:
+                        await self._run_verification()
+                    finally:
+                        self._environment.default_user = None
+
+            except asyncio.CancelledError as e:
+                self._logger.debug(f"Trial {self.config.trial_name} cancelled")
+                if self.result.exception_info is None:
+                    self.result.exception_info = ExceptionInfo.from_exception(e)
+                    self._trial_paths.exception_message_path.write_text(
+                        traceback.format_exc()
+                    )
+
+                await self._maybe_download_logs(
+                    source_dir=self._environment.env_paths.agent_dir.as_posix(),
+                    target_dir=self._trial_paths.agent_dir,
                 )
+                self._maybe_populate_agent_context(self.result.agent_result)
+                if not self._task.has_steps:
+                    await self._collect_artifacts()
+                await self._invoke_hooks(TrialEvent.CANCEL)
 
-            await self._maybe_download_logs(
-                source_dir=self._environment.env_paths.agent_dir.as_posix(),
-                target_dir=self._trial_paths.agent_dir,
-            )
-            self._maybe_populate_agent_context(self.result.agent_result)
-            if not self._task.has_steps:
-                await self._collect_artifacts()
-            await self._invoke_hooks(TrialEvent.CANCEL)
+                raise e
 
-            raise e
+            except Exception as e:
+                self._logger.debug(f"Trial {self.config.trial_name} failed: {e}")
 
-        except Exception as e:
-            self._logger.debug(f"Trial {self.config.trial_name} failed: {e}")
-
-            await self._maybe_download_logs(
-                source_dir=self._environment.env_paths.agent_dir.as_posix(),
-                target_dir=self._trial_paths.agent_dir,
-            )
-            self._maybe_populate_agent_context(self.result.agent_result)
-
-            if self.result.exception_info is None:
-                self.result.exception_info = ExceptionInfo.from_exception(e)
-                self._trial_paths.exception_message_path.write_text(
-                    traceback.format_exc()
+                await self._maybe_download_logs(
+                    source_dir=self._environment.env_paths.agent_dir.as_posix(),
+                    target_dir=self._trial_paths.agent_dir,
                 )
+                self._maybe_populate_agent_context(self.result.agent_result)
 
-            if not self._task.has_steps:
-                await self._collect_artifacts()
+                if self.result.exception_info is None:
+                    self.result.exception_info = ExceptionInfo.from_exception(e)
+                    self._trial_paths.exception_message_path.write_text(
+                        traceback.format_exc()
+                    )
 
+                if not self._task.has_steps:
+                    await self._collect_artifacts()
+
+            finally:
+                await self._cleanup_and_finalize()
+
+            return self.result
         finally:
-            await self._cleanup_and_finalize()
             self._close_logger_handler()
 
-        return self.result

--- a/src/pier/verifier/verifier.py
+++ b/src/pier/verifier/verifier.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 import logging
 from pathlib import Path
+import time
 
 from pier.environments.base import BaseEnvironment
 from pier.utils.scripts import (
@@ -13,6 +15,37 @@ from pier.models.trial.paths import TrialPaths
 from pier.models.verifier.result import VerifierResult
 from pier.utils.env import resolve_env_vars
 from pier.utils.logger import logger as global_logger
+
+
+class VerifierTimeoutError(asyncio.TimeoutError):
+    """Base exception for all verifier timeout errors."""
+    pass
+
+
+class VerifierEnvironmentTimeoutError(VerifierTimeoutError):
+    """Raised when verifier environment startup or build times out."""
+    pass
+
+
+class VerifierArtifactTransferTimeoutError(VerifierTimeoutError):
+    """Raised when artifact transfer, directory setup, or test upload times out."""
+    pass
+
+
+class VerifierTestExecutionTimeoutError(VerifierTimeoutError):
+    """Raised when the candidate test execution command itself times out."""
+    pass
+
+
+class VerifierRewardParseTimeoutError(VerifierTimeoutError):
+    """Raised when downloading or parsing verifier rewards times out."""
+    pass
+
+
+VerifierEnvironmentStartTimeoutError = VerifierEnvironmentTimeoutError
+VerifierInfrastructureTimeoutError = VerifierArtifactTransferTimeoutError
+VerifierRewardTimeoutError = VerifierRewardParseTimeoutError
+VerifierRewardDownloadTimeoutError = VerifierRewardParseTimeoutError
 
 
 class AddTestsDirError(Exception):
@@ -127,23 +160,50 @@ class Verifier:
             f"or {self._task.paths.test_path_for(task_os)}"
         )
 
-    async def verify(self) -> VerifierResult:
+    async def verify(
+        self,
+        *,
+        timeout_sec: float | None = None,
+        deadline: float | None = None,
+    ) -> VerifierResult:
         """
         Grades the agents performance based on the environment.
         Returns:
             (VerifierResult): The result of the verifier.
         """
+        if deadline is None and timeout_sec is not None:
+            deadline = time.monotonic() + timeout_sec
+
+        def _remaining_sec() -> float | None:
+            if deadline is None:
+                return timeout_sec
+            rem = deadline - time.monotonic()
+            return max(0.0, rem)
+
         env_paths = self._environment.env_paths
         task_os = self._task.config.environment.os
         test_source_dirs, tests_source_dir, host_test_path = self._resolve_tests()
 
         if not self._skip_tests_upload:
+            rem = _remaining_sec()
+            if rem is not None and rem <= 0:
+                raise VerifierArtifactTransferTimeoutError(
+                    f"Verifier test upload timed out (verifier timeout of {timeout_sec}s exhausted)"
+                )
             try:
                 for source_dir in test_source_dirs:
-                    await self._environment.upload_dir(
+                    upload_coro = self._environment.upload_dir(
                         source_dir=source_dir,
                         target_dir=str(env_paths.tests_dir),
                     )
+                    if rem is not None:
+                        await asyncio.wait_for(upload_coro, timeout=rem)
+                    else:
+                        await upload_coro
+            except asyncio.TimeoutError as e:
+                raise VerifierArtifactTransferTimeoutError(
+                    f"Verifier test upload timed out after {timeout_sec} seconds"
+                ) from e
             except Exception as e:
                 raise AddTestsDirError(
                     "Failed to add tests directory to environment."
@@ -182,24 +242,66 @@ class Verifier:
         )
 
         if needs_chmod(test_script_path):
-            await self._environment.exec(
-                command=f"chmod +x {quote_shell_arg(test_script_path, task_os)}",
-                user="root",
-            )
+            rem = _remaining_sec()
+            if rem is not None and rem <= 0:
+                raise VerifierArtifactTransferTimeoutError(
+                    f"Verifier test chmod timed out (verifier timeout of {timeout_sec}s exhausted)"
+                )
+            try:
+                chmod_coro = self._environment.exec(
+                    command=f"chmod +x {quote_shell_arg(test_script_path, task_os)}",
+                    user="root",
+                )
+                if rem is not None:
+                    await asyncio.wait_for(chmod_coro, timeout=rem)
+                else:
+                    await chmod_coro
+            except asyncio.TimeoutError as e:
+                raise VerifierArtifactTransferTimeoutError(
+                    f"Verifier test chmod timed out after {timeout_sec} seconds"
+                ) from e
 
         # Runs as ``environment.default_user``, which the caller must set to the
         # effective verifier user (step-level override or task-level fallback).
-        await self._environment.exec(
-            command=command,
-            env=env,
-        )
+        rem = _remaining_sec()
+        if rem is not None and rem <= 0:
+            raise VerifierTestExecutionTimeoutError(
+                f"Candidate test execution timed out (verifier timeout of {timeout_sec}s exhausted)"
+            )
+        try:
+            exec_coro = self._environment.exec(
+                command=command,
+                env=env,
+            )
+            if rem is not None:
+                await asyncio.wait_for(exec_coro, timeout=rem)
+            else:
+                await exec_coro
+        except asyncio.TimeoutError as e:
+            raise VerifierTestExecutionTimeoutError(
+                f"Candidate test execution timed out after {timeout_sec} seconds"
+            ) from e
+
+        rem = _remaining_sec()
+        if rem is not None and rem <= 0:
+            raise VerifierRewardParseTimeoutError(
+                f"Verifier reward download or parse timed out (verifier timeout of {timeout_sec}s exhausted)"
+            )
 
         if not self._environment.capabilities.mounted:
             try:
-                await self._environment.download_dir(
+                dl_coro = self._environment.download_dir(
                     source_dir=str(env_paths.verifier_dir),
                     target_dir=self._trial_paths.verifier_dir,
                 )
+                if rem is not None:
+                    await asyncio.wait_for(dl_coro, timeout=rem)
+                else:
+                    await dl_coro
+            except asyncio.TimeoutError as e:
+                raise VerifierRewardParseTimeoutError(
+                    f"Verifier reward directory download timed out after {timeout_sec} seconds"
+                ) from e
             except Exception as e:
                 raise DownloadVerifierDirError(
                     "Failed to download verifier directory from environment"
@@ -217,3 +319,4 @@ class Verifier:
             )
 
         return VerifierResult(rewards=rewards)
+

--- a/tests/test_verifier_timeout.py
+++ b/tests/test_verifier_timeout.py
@@ -1,0 +1,436 @@
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pier.models.job.config import RetryConfig
+from pier.models.task.config import (
+    VerifierConfig as TaskVerifierConfig,
+)
+from pier.models.task.task import Task
+from pier.models.trial.config import (
+    EnvironmentConfig,
+    TaskConfig as TrialTaskConfig,
+    TrialConfig,
+    VerifierConfig as TrialVerifierConfig,
+)
+from pier.models.trial.paths import TrialPaths
+from pier.models.trial.result import StepResult, TimingInfo, TrialResult
+from pier.models.verifier.result import VerifierResult
+from pier.trial.trial import (
+    Trial,
+    VerifierArtifactTransferTimeoutError,
+    VerifierEnvironmentStartTimeoutError,
+    VerifierEnvironmentTimeoutError,
+    VerifierInfrastructureTimeoutError,
+    VerifierRewardDownloadTimeoutError,
+    VerifierRewardParseTimeoutError,
+    VerifierRewardTimeoutError,
+    VerifierTestExecutionTimeoutError,
+    VerifierTimeoutError,
+)
+from pier.verifier.verifier import Verifier
+
+
+def _create_dummy_task_dir(tmpdir: Path) -> Path:
+    task_dir = tmpdir / "task"
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "task.toml").write_text("[environment]\nos = 'linux'\n")
+    (task_dir / "instruction.md").write_text("Test task instruction\n")
+    env_dir = task_dir / "environment"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    (env_dir / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    (task_dir / "tests").mkdir(parents=True, exist_ok=True)
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    return task_dir
+
+
+# ============================================================================
+# 1. Exception Hierarchy Tests
+# ============================================================================
+
+
+def test_verifier_timeout_exception_hierarchy():
+    """Verify timeout subphases inherit from VerifierTimeoutError and asyncio.TimeoutError."""
+    assert issubclass(VerifierTimeoutError, asyncio.TimeoutError)
+    assert issubclass(VerifierEnvironmentTimeoutError, VerifierTimeoutError)
+    assert issubclass(VerifierArtifactTransferTimeoutError, VerifierTimeoutError)
+    assert issubclass(VerifierTestExecutionTimeoutError, VerifierTimeoutError)
+    assert issubclass(VerifierRewardParseTimeoutError, VerifierTimeoutError)
+
+    # Aliases
+    assert VerifierEnvironmentStartTimeoutError is VerifierEnvironmentTimeoutError
+    assert VerifierInfrastructureTimeoutError is VerifierArtifactTransferTimeoutError
+    assert VerifierRewardTimeoutError is VerifierRewardParseTimeoutError
+    assert VerifierRewardDownloadTimeoutError is VerifierRewardParseTimeoutError
+
+
+# ============================================================================
+# 2. Config & Backward Compatibility Tests
+# ============================================================================
+
+
+def test_verifier_config_defaults_and_max_attempts():
+    """Verify default max_attempts and custom values."""
+    cfg = TrialVerifierConfig()
+    assert cfg.max_attempts == 2
+
+    cfg_single = TrialVerifierConfig(max_attempts=1)
+    assert cfg_single.max_attempts == 1
+
+    # max_retries backward compatibility
+    cfg_retries_0 = TrialVerifierConfig.model_validate({"max_retries": 0})
+    assert cfg_retries_0.max_attempts == 1
+
+    cfg_retries_2 = TrialVerifierConfig.model_validate({"max_retries": 2})
+    assert cfg_retries_2.max_attempts == 3
+
+    # TaskVerifierConfig
+    task_vcfg = TaskVerifierConfig()
+    assert task_vcfg.max_attempts is None
+    assert "currently wraps environment startup" in TaskVerifierConfig.model_fields["timeout_sec"].description
+
+
+def test_retry_config_excludes_candidate_test_timeout():
+    """Verify candidate test timeout and reward parse timeouts are excluded from outer job retries."""
+    retry_cfg = RetryConfig()
+    assert "VerifierTestExecutionTimeoutError" in retry_cfg.exclude_exceptions
+    assert "VerifierRewardParseTimeoutError" in retry_cfg.exclude_exceptions
+    assert "VerifierEnvironmentTimeoutError" not in retry_cfg.exclude_exceptions
+    assert "VerifierArtifactTransferTimeoutError" not in retry_cfg.exclude_exceptions
+
+
+# ============================================================================
+# 3. Verifier Subphase Timeout Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_verifier_test_execution_timeout():
+    """Candidate test execution command timing out raises VerifierTestExecutionTimeoutError."""
+    mock_env = MagicMock()
+    mock_env.env_paths.tests_dir = Path("/tests")
+    mock_env.env_paths.verifier_dir = Path("/verifier")
+    mock_env.capabilities.mounted = True
+
+    async def mock_exec(command, *args, **kwargs):
+        if "chmod" in command:
+            return
+        await asyncio.sleep(0.2)
+
+    mock_env.exec = AsyncMock(side_effect=mock_exec)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trial_paths = TrialPaths(Path(tmpdir))
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+
+        task = Task(task_dir)
+        verifier = Verifier(
+            task=task,
+            trial_paths=trial_paths,
+            environment=mock_env,
+            skip_tests_upload=True,
+        )
+
+        with pytest.raises(VerifierTestExecutionTimeoutError):
+            await verifier.verify(timeout_sec=0.05)
+
+
+@pytest.mark.asyncio
+async def test_verifier_upload_timeout():
+    """Test upload timing out raises VerifierArtifactTransferTimeoutError."""
+    mock_env = MagicMock()
+    mock_env.env_paths.tests_dir = Path("/tests")
+    mock_env.env_paths.verifier_dir = Path("/verifier")
+
+    async def mock_upload(*args, **kwargs):
+        await asyncio.sleep(0.2)
+
+    mock_env.upload_dir = AsyncMock(side_effect=mock_upload)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trial_paths = TrialPaths(Path(tmpdir))
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+
+        task = Task(task_dir)
+        verifier = Verifier(
+            task=task,
+            trial_paths=trial_paths,
+            environment=mock_env,
+            skip_tests_upload=False,
+        )
+
+        with pytest.raises(VerifierArtifactTransferTimeoutError):
+            await verifier.verify(timeout_sec=0.05)
+
+
+# ============================================================================
+# 4. Trial Retry Behavior & Durable State Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_trial_candidate_test_timeout_is_not_retried():
+    """A candidate test execution timeout must NOT be retried even if max_attempts=2."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+        task = Task(task_dir)
+        trials_dir = Path(tmpdir) / "trials"
+        trial_cfg = TrialConfig(
+            trial_name="test_trial",
+            trials_dir=trials_dir,
+            task=TrialTaskConfig(path=task_dir),
+            environment=EnvironmentConfig(type="docker"),
+            verifier=TrialVerifierConfig(max_attempts=2),
+        )
+
+        trial = Trial(trial_cfg, _task=task)
+        try:
+            trial._result = TrialResult(
+                trial_name="test_trial",
+                task_name="task",
+                task_id=trial_cfg.task.get_task_id(),
+                started_at=TimingInfo().started_at,
+                config=trial_cfg,
+                task_checksum="dummy",
+                trial_uri=trial._trial_paths.trial_dir.as_uri(),
+                agent_info=trial._agent.to_agent_info(),
+                source="test",
+            )
+            trial.result.verifier = TimingInfo()
+
+            verify_mock = AsyncMock(
+                side_effect=VerifierTestExecutionTimeoutError("Candidate test timed out")
+            )
+            trial._verify_once = verify_mock
+
+            with pytest.raises(VerifierTestExecutionTimeoutError):
+                await trial._verify_with_retry()
+
+            # Candidate test timeout should NOT be retried!
+            assert verify_mock.call_count == 1
+            assert trial.result.verifier_attempt == 1
+            assert trial.result.max_verifier_attempts == 2
+
+            # Check progress.json
+            progress_path = trial._trial_paths.progress_path
+            assert progress_path.exists()
+            progress_data = json.loads(progress_path.read_text())
+            assert progress_data["verifier_attempt"] == 1
+            assert progress_data["max_verifier_attempts"] == 2
+        finally:
+            trial._close_logger_handler()
+
+
+@pytest.mark.asyncio
+async def test_trial_infrastructure_timeout_retried_up_to_max_attempts():
+    """Infrastructure timeouts (e.g. environment startup or artifact transfer) ARE retried up to max_attempts."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+        task = Task(task_dir)
+        trials_dir = Path(tmpdir) / "trials"
+        trial_cfg = TrialConfig(
+            trial_name="test_trial",
+            trials_dir=trials_dir,
+            task=TrialTaskConfig(path=task_dir),
+            environment=EnvironmentConfig(type="docker"),
+            verifier=TrialVerifierConfig(max_attempts=2),
+        )
+
+        trial = Trial(trial_cfg, _task=task)
+        try:
+            trial._result = TrialResult(
+                trial_name="test_trial",
+                task_name="task",
+                task_id=trial_cfg.task.get_task_id(),
+                started_at=TimingInfo().started_at,
+                config=trial_cfg,
+                task_checksum="dummy",
+                trial_uri=trial._trial_paths.trial_dir.as_uri(),
+                agent_info=trial._agent.to_agent_info(),
+                source="test",
+            )
+            trial.result.verifier = TimingInfo()
+
+            # First attempt fails with infra timeout, second succeeds
+            verify_mock = AsyncMock(
+                side_effect=[
+                    VerifierArtifactTransferTimeoutError("Transfer timed out"),
+                    VerifierResult(rewards={"reward": 1.0}),
+                ]
+            )
+            trial._verify_once = verify_mock
+
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await trial._verify_with_retry()
+
+            assert verify_mock.call_count == 2
+            assert trial.result.verifier_attempt == 2
+            assert trial.result.max_verifier_attempts == 2
+            assert trial.result.verifier.attempt == 2
+            assert trial.result.verifier.max_attempts == 2
+            assert trial.result.verifier_result.rewards == {"reward": 1.0}
+        finally:
+            trial._close_logger_handler()
+
+
+@pytest.mark.asyncio
+async def test_trial_max_attempts_one_disables_retries():
+    """Setting max_attempts=1 disables all retries even on infrastructure timeouts."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+        task = Task(task_dir)
+        trials_dir = Path(tmpdir) / "trials"
+        trial_cfg = TrialConfig(
+            trial_name="test_trial",
+            trials_dir=trials_dir,
+            task=TrialTaskConfig(path=task_dir),
+            environment=EnvironmentConfig(type="docker"),
+            verifier=TrialVerifierConfig(max_attempts=1),
+        )
+
+        trial = Trial(trial_cfg, _task=task)
+        try:
+            trial._result = TrialResult(
+                trial_name="test_trial",
+                task_name="task",
+                task_id=trial_cfg.task.get_task_id(),
+                started_at=TimingInfo().started_at,
+                config=trial_cfg,
+                task_checksum="dummy",
+                trial_uri=trial._trial_paths.trial_dir.as_uri(),
+                agent_info=trial._agent.to_agent_info(),
+                source="test",
+            )
+            trial.result.verifier = TimingInfo()
+
+            verify_mock = AsyncMock(
+                side_effect=VerifierEnvironmentTimeoutError("Env startup timed out")
+            )
+            trial._verify_once = verify_mock
+
+            with pytest.raises(VerifierEnvironmentTimeoutError):
+                await trial._verify_with_retry()
+
+            assert verify_mock.call_count == 1
+            assert trial.result.verifier_attempt == 1
+            assert trial.result.max_verifier_attempts == 1
+        finally:
+            trial._close_logger_handler()
+
+
+# ============================================================================
+# 5. StepResult & TimingInfo Models
+# ============================================================================
+
+
+def test_step_result_and_timing_info_attempts():
+    timing = TimingInfo(attempt=1, max_attempts=2)
+    assert timing.attempt == 1
+    assert timing.max_attempts == 2
+
+    step = StepResult(
+        step_name="step1",
+        verifier_attempt=1,
+        max_verifier_attempts=2,
+    )
+    assert step.step_name == "step1"
+    assert step.verifier_attempt == 1
+    assert step.max_verifier_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_verifier_reward_download_timeout():
+    """Verifier reward download timing out raises VerifierRewardParseTimeoutError."""
+    mock_env = MagicMock()
+    mock_env.env_paths.tests_dir = Path("/tests")
+    mock_env.env_paths.verifier_dir = Path("/verifier")
+    mock_env.capabilities.mounted = False
+
+    async def mock_exec(command, *args, **kwargs):
+        return
+
+    async def mock_download(*args, **kwargs):
+        await asyncio.sleep(0.2)
+
+    mock_env.exec = AsyncMock(side_effect=mock_exec)
+    mock_env.download_dir = AsyncMock(side_effect=mock_download)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trial_paths = TrialPaths(Path(tmpdir))
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+
+        task = Task(task_dir)
+        verifier = Verifier(
+            task=task,
+            trial_paths=trial_paths,
+            environment=mock_env,
+            skip_tests_upload=True,
+        )
+
+        with pytest.raises(VerifierRewardParseTimeoutError):
+            await verifier.verify(timeout_sec=0.05)
+
+
+@pytest.mark.asyncio
+async def test_trial_durable_result_json_and_progress_json():
+    """Verify result.json and progress.json contain verifier_attempt and max_verifier_attempts."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        task_dir = _create_dummy_task_dir(Path(tmpdir))
+        task = Task(task_dir)
+        trials_dir = Path(tmpdir) / "trials"
+        trial_cfg = TrialConfig(
+            trial_name="test_trial",
+            trials_dir=trials_dir,
+            task=TrialTaskConfig(path=task_dir),
+            environment=EnvironmentConfig(type="docker"),
+            verifier=TrialVerifierConfig(max_attempts=3),
+        )
+
+        trial = Trial(trial_cfg, _task=task)
+        try:
+            trial._result = TrialResult(
+                trial_name="test_trial",
+                task_name="task",
+                task_id=trial_cfg.task.get_task_id(),
+                started_at=TimingInfo().started_at,
+                config=trial_cfg,
+                task_checksum="dummy",
+                trial_uri=trial._trial_paths.trial_dir.as_uri(),
+                agent_info=trial._agent.to_agent_info(),
+                source="test",
+            )
+            trial.result.verifier_attempt = 2
+            trial.result.max_verifier_attempts = 3
+            trial._stop_agent_environment = AsyncMock()
+
+            await trial._cleanup_and_finalize()
+
+            assert trial._trial_paths.result_path.exists()
+            result_data = json.loads(trial._trial_paths.result_path.read_text())
+            assert result_data["verifier_attempt"] == 2
+            assert result_data["max_verifier_attempts"] == 3
+
+            assert trial._trial_paths.progress_path.exists()
+            progress_data = json.loads(trial._trial_paths.progress_path.read_text())
+            assert progress_data["phase"] == "completed"
+            assert progress_data["verifier_attempt"] == 2
+            assert progress_data["max_verifier_attempts"] == 3
+        finally:
+            trial._close_logger_handler()
+
+
+def test_cli_verifier_max_attempts_option():
+    """Verify --verifier-max-attempts CLI option is exposed in pier run --help."""
+    from typer.testing import CliRunner
+    from pier.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "--help"], env={"COLUMNS": "200"})
+    assert result.exit_code == 0
+    assert "--verifier-max-attempts" in result.output
+
+


### PR DESCRIPTION
## Summary
Fixes #41.

Currently, the verifier retry loop was hardcoded to 2 attempts using tenacity and caught generic `VerifierTimeoutError`. Because `verifier.timeout_sec` wrapped all verification steps together (container startup, artifact sync, candidate test execution, and reward parsing), if candidate tests hung (e.g. infinite loop), it would needlessly retry a second 30-minute attempt.

This PR:
1. Makes verifier attempt count configurable via `max_attempts` on `VerifierConfig` (defaults to 2, setting to 1 disables retries). Keeps backward compatibility with `max_retries`.
2. Adds `--verifier-max-attempts` / `--verifier-attempts` to the CLI (`pier run` / `pier job`).
3. Breaks down verifier timeouts into subphases inheriting from `VerifierTimeoutError`:
   - `VerifierEnvironmentTimeoutError` (environment startup / build)
   - `VerifierArtifactTransferTimeoutError` (test file upload / directory transfers)
   - `VerifierTestExecutionTimeoutError` (candidate test script execution)
   - `VerifierRewardParseTimeoutError` (reward download / parsing)
4. Updates retry logic so proven candidate test execution timeouts (`VerifierTestExecutionTimeoutError`) fail fast on the first attempt without retrying. Transient infrastructure timeouts can still retry up to `max_attempts`.
5. Excludes candidate test timeouts and reward parse timeouts from outer job retries (`RetryConfig.exclude_exceptions`).
6. Tracks active and max verifier attempts in `progress.json`, `result.json`, `TimingInfo`, `TrialResult`, and `StepResult`.
7. Documents in `TaskVerifierConfig.timeout_sec` that `verifier.timeout_sec` wraps environment startup and test execution together.

## Testing
- Added unit tests in `tests/test_verifier_timeout.py` covering all timeout subphases, fail-fast behavior on candidate hangs, infrastructure retries, single-attempt mode, durable progress persistence, and CLI option parsing.
- Ran test suite: `pytest tests/test_verifier_timeout.py` (all 12 pass).
- Verified existing tests: `pytest tests/test_trial_verifier_artifact_transfer.py tests/test_trial_artifacts.py` (all 20 pass).
